### PR TITLE
Enable LM saving

### DIFF
--- a/src/gt4sd/algorithms/__init__.py
+++ b/src/gt4sd/algorithms/__init__.py
@@ -31,6 +31,11 @@ from .generation.hugging_face.core import (  # noqa: F401
     HuggingFaceXLMGenerator,
     HuggingFaceXLNetGenerator,
 )
+from .generation.pgt.core import (  # noqa: F401
+    PGTCoherenceChecker,
+    PGTEditor,
+    PGTGenerator,
+)
 from .generation.polymer_blocks.core import PolymerBlocksGenerator  # noqa: F401
 from .prediction.paccmann.core import PaccMann  # noqa: F401
 from .prediction.topics_zero_shot.core import TopicsPredictor  # noqa: F401

--- a/src/gt4sd/algorithms/core.py
+++ b/src/gt4sd/algorithms/core.py
@@ -439,11 +439,11 @@ class AlgorithmConfiguration(Generic[S, T]):
         )
 
     @classmethod
-    def save_postprocess(
+    def save_version_from_training_pipeline_arguments_postprocess(
         cls,
         training_pipeline_arguments: TrainingPipelineArguments,
     ):
-        """Postprocess after saving
+        """Postprocess after saving.
 
         Args:
             training_pipeline_arguments: training pipeline arguments.
@@ -506,7 +506,9 @@ class AlgorithmConfiguration(Generic[S, T]):
                 )
                 shutil.copyfile(source_filepath, target_filepath)
 
-            cls.save_postprocess(training_pipeline_arguments)
+            cls.save_version_from_training_pipeline_arguments_postprocess(
+                training_pipeline_arguments
+            )
 
             logger.info(f"Artifacts saving completed into {target_path}")
 

--- a/src/gt4sd/algorithms/core.py
+++ b/src/gt4sd/algorithms/core.py
@@ -439,6 +439,18 @@ class AlgorithmConfiguration(Generic[S, T]):
         )
 
     @classmethod
+    def save_postprocess(
+        cls,
+        training_pipeline_arguments: TrainingPipelineArguments,
+    ):
+        """Postprocess after saving
+
+        Args:
+            training_pipeline_arguments: training pipeline arguments.
+        """
+        pass
+
+    @classmethod
     def save_version_from_training_pipeline_arguments(
         cls,
         training_pipeline_arguments: TrainingPipelineArguments,
@@ -493,6 +505,9 @@ class AlgorithmConfiguration(Generic[S, T]):
                     f"Saving artifact {source_filepath} into {target_filepath}..."
                 )
                 shutil.copyfile(source_filepath, target_filepath)
+
+            cls.save_postprocess(training_pipeline_arguments)
+
             logger.info(f"Artifacts saving completed into {target_path}")
 
     @classmethod

--- a/src/gt4sd/algorithms/generation/pgt/core.py
+++ b/src/gt4sd/algorithms/generation/pgt/core.py
@@ -170,7 +170,7 @@ class PGTAlgorithmConfiguration(AlgorithmConfiguration[str, None]):
         )
 
     @classmethod
-    def save_postprocess(
+    def save_version_from_training_pipeline_arguments_postprocess(
         cls,
         training_pipeline_arguments: TrainingPipelineArguments,
     ):
@@ -189,7 +189,9 @@ class PGTAlgorithmConfiguration(AlgorithmConfiguration[str, None]):
                     f"Cleaning up temporary files from {training_pipeline_arguments.hf_model_path}"
                 )
         else:
-            return super().save_postprocess(training_pipeline_arguments)
+            return super().save_version_from_training_pipeline_arguments_postprocess(
+                training_pipeline_arguments
+            )
 
     @classmethod
     def get_filepath_mappings_for_training_pipeline_arguments(

--- a/src/gt4sd/algorithms/generation/pgt/core.py
+++ b/src/gt4sd/algorithms/generation/pgt/core.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import shutil
 from dataclasses import field
 from typing import Any, ClassVar, Dict, Optional, TypeVar
 
@@ -170,6 +171,28 @@ class PGTAlgorithmConfiguration(AlgorithmConfiguration[str, None]):
             top_p=self.top_p,
             num_return_sequences=self.num_return_sequences,
         )
+
+    @classmethod
+    def save_postprocess(
+        cls,
+        training_pipeline_arguments: TrainingPipelineArguments,
+    ):
+        """Postprocess after saving. Remove temporarily converted hf model
+           if pytorch-lightning checkpoint is given.
+
+        Args:
+            training_pipeline_arguments: training pipeline arguments.
+        """
+
+        if isinstance(training_pipeline_arguments, LanguageModelingSavingArguments):
+            if training_pipeline_arguments.ckpt is not None:
+                shutil.rmtree(training_pipeline_arguments.hf_model_path)
+
+                logger.info(
+                    f"Cleaning up temporary files from {training_pipeline_arguments.hf_model_path}"
+                )
+        else:
+            return super().save_postprocess(training_pipeline_arguments)
 
     @classmethod
     def get_filepath_mappings_for_training_pipeline_arguments(

--- a/src/gt4sd/algorithms/generation/pgt/core.py
+++ b/src/gt4sd/algorithms/generation/pgt/core.py
@@ -114,8 +114,6 @@ class PGTAlgorithmConfiguration(AlgorithmConfiguration[str, None]):
     domain: ClassVar[str] = "nlp"
     algorithm_version: str = "v0"
 
-    prompt: str = "Do not change me, I am an interesting prompt that is changed internally for each task."
-
     model_type: str = field(
         default="",
         metadata=dict(description="Type of the model."),
@@ -165,7 +163,6 @@ class PGTAlgorithmConfiguration(AlgorithmConfiguration[str, None]):
             resources_path=resources_path,
             model_type=self.model_type,
             model_name=self.algorithm_version,
-            prompt=self.prompt,
             max_length=self.max_length,
             top_k=self.top_k,
             top_p=self.top_p,

--- a/src/gt4sd/algorithms/generation/pgt/implementation.py
+++ b/src/gt4sd/algorithms/generation/pgt/implementation.py
@@ -60,11 +60,11 @@ class Generator:
         resources_path: str,
         model_type: str,
         model_name: str,
-        prompt: str,
         max_length: int,
         top_k: int,
         top_p: float,
         num_return_sequences: int,
+        prompt: str = "This is an interesting prompt",
         no_repeat_ngram_size: int = 2,
         device: Optional[Union[torch.device, str]] = None,
     ):

--- a/src/gt4sd/frameworks/granular/dataloader/dataset.py
+++ b/src/gt4sd/frameworks/granular/dataloader/dataset.py
@@ -36,6 +36,11 @@ class GranularDataset(Dataset):
         """
         self.dataset: Dict[str, Any] = {"name": name, "data": data}
 
+        self.tokenizer: Tokenizer
+        self.set_seq_size: int
+        self.input_size: int
+        self.target_size: int
+
     def __len__(self) -> int:
         """Dataset length.
 

--- a/src/gt4sd/training_pipelines/__init__.py
+++ b/src/gt4sd/training_pipelines/__init__.py
@@ -23,6 +23,7 @@ from .pytorch_lightning.granular.core import (
 from .pytorch_lightning.language_modeling.core import (
     LanguageModelingDataArguments,
     LanguageModelingModelArguments,
+    LanguageModelingSavingArguments,
     LanguageModelingTrainingPipeline,
 )
 
@@ -61,6 +62,7 @@ TRAINING_PIPELINE_MAPPING = {
 TRAINING_PIPELINE_ARGUMENTS_FOR_MODEL_SAVING = {
     "paccmann-vae-trainer": PaccMannSavingArguments,
     "granular-trainer": GranularSavingArguments,
+    "language-modeling-trainer": LanguageModelingSavingArguments,
 }
 
 

--- a/src/gt4sd/training_pipelines/pytorch_lightning/language_modeling/core.py
+++ b/src/gt4sd/training_pipelines/pytorch_lightning/language_modeling/core.py
@@ -256,6 +256,7 @@ class LanguageModelingSavingArguments(TrainingPipelineArguments):
 
     hf_model_path: str = field(
         metadata={"help": "Path to the converted HF model."},
+        default="/tmp/gt4sd_lm_saving_tmp",
     )
     training_type: Optional[str] = field(
         metadata={

--- a/src/gt4sd/training_pipelines/pytorch_lightning/language_modeling/core.py
+++ b/src/gt4sd/training_pipelines/pytorch_lightning/language_modeling/core.py
@@ -9,7 +9,7 @@ from pytorch_lightning import LightningDataModule, LightningModule
 from ...core import TrainingPipelineArguments
 from ..core import PyTorchLightningTrainingPipeline
 from .lm_datasets import CGMDataModule, CLMDataModule, MLMDataModule, PLMDataModule
-from .models import CGMModule, CLMModule, MLMModule, PLMModule
+from .models import LM_MODULE_FACTORY, CGMModule, CLMModule, MLMModule, PLMModule
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -245,4 +245,34 @@ class LanguageModelingDataArguments(TrainingPipelineArguments):
     batch_size: int = field(
         default=8,
         metadata={"help": "Ratio of tokens to mask for masked language modeling loss."},
+    )
+
+
+@dataclass
+class LanguageModelingSavingArguments(TrainingPipelineArguments):
+    """Saving arguments related to LM trainer."""
+
+    __name__ = "saving_args"
+
+    hf_model_path: str = field(
+        metadata={"help": "Path to the converted HF model."},
+    )
+    training_type: Optional[str] = field(
+        metadata={
+            "help": f"Training type of the converted model, supported types: {', '.join(LM_MODULE_FACTORY.keys())}."
+        },
+        default=None,
+    )
+    model_name_or_path: Optional[str] = field(
+        metadata={
+            "help": "Model name or path.",
+        },
+        default=None,
+    )
+    ckpt: Optional[str] = field(metadata={"help": "Path to checkpoint."}, default=None)
+    tokenizer_name_or_path: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Tokenizer name or path. If not provided defaults to model_name_or_path."
+        },
     )

--- a/src/gt4sd/training_pipelines/pytorch_lightning/language_modeling/models.py
+++ b/src/gt4sd/training_pipelines/pytorch_lightning/language_modeling/models.py
@@ -267,5 +267,6 @@ LM_MODULE_FACTORY: Dict[str, Type[LMModule]] = {
     "lm": LMModule,
     "mlm": MLMModule,
     "clm": CLMModule,
+    "cgm": CGMModule,
     "plm": PLMModule,
 }


### PR DESCRIPTION
Enable the use of saving-cli for Language Models. The given language models could be: 
-  a hugging face model (including its tokenizer) or 
-  a pytorch-lightning checkpoint.
 
In the later case, a conversion to hugging face format will also take place during saving. 