### PR TITLE
doc: pin jinja2 version to fix doc deployment

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -12,3 +12,4 @@ myst-parser==0.13.3
 flask==1.1.2
 flask_login==0.5.0
 docutils==0.17.1
+jinja2<3.1.0


### PR DESCRIPTION
Merge of #53 into master failed because the new docs were deployed and `jinja2` released a new version that breaks the doc generation via sphinx.

For details see issue here: https://github.com/sphinx-doc/sphinx/issues/10291

Fix: pin `jinja2`.