### PR TITLE
granular trainer: search for the models in the given config by default

### DIFF
--- a/src/gt4sd/cli/trainer.py
+++ b/src/gt4sd/cli/trainer.py
@@ -157,6 +157,7 @@ def main() -> None:
     configuration_filepath = base_args.configuration_file
     if configuration_filepath:
         args = parser.parse_json_file(json_file=configuration_filepath)
+
     else:
         args = parser.parse_args_into_dataclasses(return_remaining_strings=True)
     config = {
@@ -164,6 +165,12 @@ def main() -> None:
         for arg in args
         if isinstance(arg, TrainingPipelineArguments) and isinstance(arg.__name__, str)
     }
+
+    if (
+        base_args.training_pipeline_name == "granular-trainer"
+        and config["model_args"]["model_list_path"] is None
+    ):
+        config["model_args"]["model_list_path"] = configuration_filepath
 
     pipeline = TRAINING_PIPELINE_MAPPING[training_pipeline_name]
     pipeline().train(**config)

--- a/src/gt4sd/training_pipelines/pytorch_lightning/granular/core.py
+++ b/src/gt4sd/training_pipelines/pytorch_lightning/granular/core.py
@@ -64,7 +64,14 @@ class GranularTrainingPipeline(PyTorchLightningTrainingPipeline):
         configuration = {**model_args, **dataset_args}
 
         with open(model_args["model_list_path"], "r") as fp:  # type:ignore
-            configuration["model_list"] = json.load(fp)["models"]
+            model_config = json.load(fp)
+
+        if "models" in model_config:
+            configuration["model_list"] = model_config["models"]
+        else:
+            raise ValueError(
+                "Models configuration is not given in the specified config file."
+            )
 
         arguments = Namespace(**configuration)
         datasets = []
@@ -116,7 +123,8 @@ class GranularModelArguments(TrainingPipelineArguments):
 
     __name__ = "model_args"
 
-    model_list_path: str = field(
+    model_list_path: Optional[str] = field(
+        default=None,
         metadata={
             "help": "Path to a json file that contains a dictionary with models and their parameters."
         },

--- a/src/gt4sd/training_pipelines/pytorch_lightning/granular/core.py
+++ b/src/gt4sd/training_pipelines/pytorch_lightning/granular/core.py
@@ -127,6 +127,7 @@ class GranularModelArguments(TrainingPipelineArguments):
         default=None,
         metadata={
             "help": "Path to a json file that contains a dictionary with models and their parameters."
+                    "If it is not provided, then the dictionary is searched in the given config file."
         },
     )
     lr: float = field(

--- a/src/gt4sd/training_pipelines/pytorch_lightning/granular/core.py
+++ b/src/gt4sd/training_pipelines/pytorch_lightning/granular/core.py
@@ -127,7 +127,7 @@ class GranularModelArguments(TrainingPipelineArguments):
         default=None,
         metadata={
             "help": "Path to a json file that contains a dictionary with models and their parameters."
-                    "If it is not provided, then the dictionary is searched in the given config file."
+            "If it is not provided, then the dictionary is searched in the given config file."
         },
     )
     lr: float = field(


### PR DESCRIPTION
Update the argument parser for the granular trainer to use the same config file to extract model's parameters if other configuration file for the models is not provided.