### PR TITLE
chore: fix bdist_wheel build by installing wheel.

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -28,6 +28,9 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install wheel
+        run: |
+          python -m pip install wheel
       - name: Build dists
         run: |
           python setup.py sdist bdist_wheel


### PR DESCRIPTION
Closes #74, related to #72.