### PR TITLE
Ci setup

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -28,25 +28,13 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install wheel
+      - name: Install build
         run: |
-          python -m pip install wheel
+          python -m pip install build
           python -m pip freeze
       - name: Build dists
         run: |
-          python setup.py sdist bdist_wheel
-      - name: Update build dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip freeze
-      - name: Build dists (again)
-        run: |
-          mv dist/ dist_/
-          python setup.py sdist bdist_wheel
-      - name: compare dists
-        run: |
-          ls -lrt dist_/
-          ls -lrt dist/
+          python -m build
       # - name: Publish to PyPI
       #   uses: pypa/gh-action-pypi-publish@release/v1
       #   with:

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -31,13 +31,12 @@ jobs:
       - name: Install build
         run: |
           python -m pip install build
-          python -m pip freeze
       - name: Build dists
         run: |
           python -m build
-      # - name: Publish to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.PYPI_TOKEN }}
-      #     skip_existing: true
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip_existing: true

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -31,12 +31,25 @@ jobs:
       - name: Install wheel
         run: |
           python -m pip install wheel
+          python -m pip freeze
       - name: Build dists
         run: |
           python setup.py sdist bdist_wheel
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-          skip_existing: true
+      - name: Update build dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip freeze
+      - name: Build dists (again)
+        run: |
+          mv -r dists/ dists_/
+          python setup.py sdist bdist_wheel
+      - name: compare dists
+        run: |
+          ls -lrt dists_/
+          ls -lrt dists/
+      # - name: Publish to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.PYPI_TOKEN }}
+      #     skip_existing: true

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -41,7 +41,7 @@ jobs:
           python -m pip freeze
       - name: Build dists (again)
         run: |
-          mv -r dists/ dists_/
+          mv dists/ dists_/
           python setup.py sdist bdist_wheel
       - name: compare dists
         run: |

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -41,12 +41,12 @@ jobs:
           python -m pip freeze
       - name: Build dists (again)
         run: |
-          mv dists/ dists_/
+          mv dist/ dist_/
           python setup.py sdist bdist_wheel
       - name: compare dists
         run: |
-          ls -lrt dists_/
-          ls -lrt dists/
+          ls -lrt dist_/
+          ls -lrt dist/
       # - name: Publish to PyPI
       #   uses: pypa/gh-action-pypi-publish@release/v1
       #   with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ setup_requires =
 package_dir =
     = src
 packages=find_namespace:
-include_package_data = True
+include_package_data = False  # would break package_data
 
 [options.entry_points]
 console_scripts=
@@ -52,10 +52,10 @@ where = src
 
 [options.package_data]
 gt4sd =
-    gt4sd/py.typed
-    gt4sd/training_pipelines/*json
-    gt4sd/training_pipelines/tests/*json
-    gt4sd/training_pipelines/tests/*smi
+    py.typed
+    training_pipelines/*json
+    training_pipelines/tests/*json
+    training_pipelines/tests/*smi
 
 [options.extras_require]
 extras =

--- a/src/gt4sd/__init__.py
+++ b/src/gt4sd/__init__.py
@@ -23,5 +23,5 @@
 #
 """Module initialization."""
 
-__version__ = "0.36.1"
+__version__ = "0.36.2.dev0"
 __name__ = "gt4sd"


### PR DESCRIPTION
https://setuptools.pypa.io/en/latest/userguide/datafiles.html:
> If using the include_package_data argument, files specified by package_data will not be automatically added to the manifest unless they are listed in the [MANIFEST.in](https://packaging.python.org/en/latest/guides/using-manifest-in/) file or by a plugin like [setuptools-scm](https://pypi.org/project/setuptools-scm) or [setuptools-svn](https://pypi.org/project/setuptools-svn).

https://github.com/GT4SD/gt4sd-core/runs/6570553643?check_suite_focus=true#step:6:103 confirms e.g. the py.typed file finally being available in the distributions.

Closes #72.

@drugilsberg This branch released a .dev prerelease version. After merge I will push a bump to 0.36.2 with a tag, and will pull 0.36.1 from pypi and delete the tag.