### PR TITLE
fix: upper bound for protobuf to fix tensorflow compatibility errors in CI.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ torchdrug>=0.1.2
 tensorflow==2.1.0
 keras==2.3.1
 sacremoses>=0.0.41
+protobuf<=3.20.1

--- a/src/gt4sd/__init__.py
+++ b/src/gt4sd/__init__.py
@@ -23,5 +23,5 @@
 #
 """Module initialization."""
 
-__version__ = "0.37.0"
+__version__ = "0.37.1"
 __name__ = "gt4sd"


### PR DESCRIPTION
This manifested in the last hour and rerunning old tests fail. To play it safe placing an upperbound on the version of protobuf from end of April 2022.

Signed-off-by: Matteo Manica <drugilsberg@gmail.com>