### PR TITLE
Artifact storage for property predictors

### DIFF
--- a/src/gt4sd/algorithms/core.py
+++ b/src/gt4sd/algorithms/core.py
@@ -747,7 +747,7 @@ class AlgorithmConfiguration(Generic[S, T]):
             )
 
     @classmethod
-    def ensure_artifacts_for_version(cls, algorithm_version: str) -> str:  # type: ignore
+    def ensure_artifacts_for_version(cls, algorithm_version: str) -> str:
         """The artifacts matching the path defined by class attributes and the given version are downloaded.
 
         That is all objects under ``algorithm_type/algorithm_name/algorithm_application/algorithm_version``
@@ -921,6 +921,7 @@ class PropertyPredictor(ABC, Generic[S, U]):
             context: the context in which a property of an item can be
                 computed or checked is very application specific.
         """
+        logger.warning("This class will be deprecated in a future release.")
         self.context = context
         # or pass these with methods?
 

--- a/src/gt4sd/configuration.py
+++ b/src/gt4sd/configuration.py
@@ -26,7 +26,7 @@
 import logging
 import os
 from functools import lru_cache
-from typing import Optional, Set
+from typing import Dict, List, Optional, Set
 
 from pydantic import BaseSettings
 
@@ -45,6 +45,7 @@ class GT4SDConfiguration(BaseSettings):
 
     gt4sd_local_cache_path: str = os.path.join(os.path.expanduser("~"), ".gt4sd")
     gt4sd_local_cache_path_algorithms: str = "algorithms"
+    gt4sd_local_cache_path_properties: str = "properties"
     gt4sd_max_number_of_stuck_calls: int = 50
     gt4sd_max_number_of_samples: int = 1000000
     gt4sd_max_runtime: int = 86400
@@ -53,13 +54,29 @@ class GT4SDConfiguration(BaseSettings):
     gt4sd_s3_access_key: str = "6e9891531d724da89997575a65f4592e"
     gt4sd_s3_secret_key: str = "5997d63c4002cc04e13c03dc0c2db9dae751293dab106ac5"
     gt4sd_s3_secure: bool = True
-    gt4sd_s3_bucket: str = "gt4sd-cos-algorithms-artifacts"
+    gt4sd_s3_bucket_algorithms: str = "gt4sd-cos-algorithms-artifacts"
+    gt4sd_s3_bucket_properties: str = "gt4sd-cos-properties-artifacts"
 
     gt4sd_s3_host_hub: str = "s3.par01.cloud-object-storage.appdomain.cloud"
     gt4sd_s3_access_key_hub: str = "d9536662ebcf462f937efb9f58012830"
     gt4sd_s3_secret_key_hub: str = "934d1f3afdaea55ac586f6c2f729ac2ba2694bb8e975ee0b"
     gt4sd_s3_secure_hub: bool = True
-    gt4sd_s3_bucket_hub: str = "gt4sd-cos-hub-algorithms-artifacts"
+    gt4sd_s3_bucket_hub_algorithms: str = "gt4sd-cos-hub-algorithms-artifacts"
+    gt4sd_s3_bucket_hub_properties: str = "gt4sd-cos-hub-properties-artifacts"
+
+    gt4sd_s3_modules: List[str] = ["algorithms", "properties"]
+    get_local_cache_path: Dict[str, str] = {
+        "algorithms": gt4sd_local_cache_path_algorithms,
+        "properties": gt4sd_local_cache_path_properties,
+    }
+    get_s3_bucket: Dict[str, str] = {
+        "algorithms": gt4sd_s3_bucket_algorithms,
+        "properties": gt4sd_s3_bucket_properties,
+    }
+    get_s3_bucket_hub: Dict[str, str] = {
+        "algorithms": gt4sd_s3_bucket_hub_algorithms,
+        "properties": gt4sd_s3_bucket_hub_properties,
+    }
 
     class Config:
         # immutable and in turn hashable, that is required for lru_cache
@@ -72,27 +89,33 @@ class GT4SDConfiguration(BaseSettings):
 
 
 gt4sd_configuration_instance = GT4SDConfiguration.get_instance()
-logger.info(
-    f"using as local cache path: {gt4sd_configuration_instance.gt4sd_local_cache_path}"
-)
-try:
-    os.makedirs(gt4sd_configuration_instance.gt4sd_local_cache_path)
-except FileExistsError:
-    logger.debug("local cache path already exists")
+
+for key, val in gt4sd_configuration_instance.get_local_cache_path.items():
+    logger.info(f"using as local cache path for {key}: {val}")
+    try:
+        os.makedirs(val)
+    except FileExistsError:
+        logger.debug(f"local cache path for {key} already exists at {val}.")
 
 
-def upload_to_s3(target_filepath: str, source_filepath: str):
+def upload_to_s3(
+    target_filepath: str, source_filepath: str, module: str = "algorithms"
+):
     """Upload an algorithm in source_filepath in target_filepath on a bucket in the model hub.
     Args:
         target_filepath: path to save the objects in s3.
         source_filepath: path to the file to sync.
     """
+
+    if module not in gt4sd_configuration_instance.gt4sd_s3_modules:
+        raise KeyError(f"Unknown submodule {module}")
+
     try:
         upload_file_to_s3(
             host=gt4sd_configuration_instance.gt4sd_s3_host_hub,
             access_key=gt4sd_configuration_instance.gt4sd_s3_access_key_hub,
             secret_key=gt4sd_configuration_instance.gt4sd_s3_secret_key_hub,
-            bucket=gt4sd_configuration_instance.gt4sd_s3_bucket_hub,
+            bucket=gt4sd_configuration_instance.get_s3_bucket_hub[module],
             target_filepath=target_filepath,
             source_filepath=source_filepath,
             secure=gt4sd_configuration_instance.gt4sd_s3_secure_hub,
@@ -101,19 +124,25 @@ def upload_to_s3(target_filepath: str, source_filepath: str):
         logger.exception("error in syncing the cache with S3")
 
 
-def sync_algorithm_with_s3(prefix: Optional[str] = None) -> str:
+def sync_algorithm_with_s3(
+    prefix: Optional[str] = None, module: str = "algorithms"
+) -> str:
     """Sync an algorithm in the local cache using environment variables.
 
     Args:
         prefix: the relative path in the bucket (both
             on S3 and locally) to match files to download. Defaults to None.
+        module: the submodule that acts as a root for the bucket.
 
     Returns:
         str: local path using the prefix.
     """
+    if module not in gt4sd_configuration_instance.gt4sd_s3_modules:
+        raise KeyError(f"Unknown submodule {module}")
+
     folder_path = os.path.join(
         gt4sd_configuration_instance.gt4sd_local_cache_path,
-        gt4sd_configuration_instance.gt4sd_local_cache_path_algorithms,
+        gt4sd_configuration_instance.get_local_cache_path[module],
     )
 
     try:
@@ -122,7 +151,7 @@ def sync_algorithm_with_s3(prefix: Optional[str] = None) -> str:
             host=gt4sd_configuration_instance.gt4sd_s3_host,
             access_key=gt4sd_configuration_instance.gt4sd_s3_access_key,
             secret_key=gt4sd_configuration_instance.gt4sd_s3_secret_key,
-            bucket=gt4sd_configuration_instance.gt4sd_s3_bucket,
+            bucket=gt4sd_configuration_instance.get_s3_bucket[module],
             folder_path=folder_path,
             prefix=prefix,
             secure=gt4sd_configuration_instance.gt4sd_s3_secure,
@@ -132,7 +161,7 @@ def sync_algorithm_with_s3(prefix: Optional[str] = None) -> str:
             host=gt4sd_configuration_instance.gt4sd_s3_host_hub,
             access_key=gt4sd_configuration_instance.gt4sd_s3_access_key_hub,
             secret_key=gt4sd_configuration_instance.gt4sd_s3_secret_key_hub,
-            bucket=gt4sd_configuration_instance.gt4sd_s3_bucket_hub,
+            bucket=gt4sd_configuration_instance.get_s3_bucket_hub[module],
             folder_path=folder_path,
             prefix=prefix,
             secure=gt4sd_configuration_instance.gt4sd_s3_secure_hub,
@@ -142,17 +171,23 @@ def sync_algorithm_with_s3(prefix: Optional[str] = None) -> str:
     return os.path.join(folder_path, prefix) if prefix is not None else folder_path
 
 
-def get_cached_algorithm_path(prefix: Optional[str] = None) -> str:
+def get_cached_algorithm_path(
+    prefix: Optional[str] = None, module: str = "algorithms"
+) -> str:
+
+    if module not in gt4sd_configuration_instance.gt4sd_s3_modules:
+        raise KeyError(f"Unknown submodule {module}")
+
     return (
         os.path.join(
             gt4sd_configuration_instance.gt4sd_local_cache_path,
-            gt4sd_configuration_instance.gt4sd_local_cache_path_algorithms,
+            gt4sd_configuration_instance.get_local_cache_path[module],
             prefix,
         )
         if prefix is not None
         else os.path.join(
             gt4sd_configuration_instance.gt4sd_local_cache_path,
-            gt4sd_configuration_instance.gt4sd_local_cache_path_algorithms,
+            gt4sd_configuration_instance.get_local_cache_path[module],
         )
     )
 
@@ -172,7 +207,9 @@ def get_algorithm_subdirectories_from_s3_coordinates(
     return client.list_directories(bucket=bucket, prefix=prefix)
 
 
-def get_algorithm_subdirectories_with_s3(prefix: Optional[str] = None) -> Set[str]:
+def get_algorithm_subdirectories_with_s3(
+    prefix: Optional[str] = None, module: str = "algorithms"
+) -> Set[str]:
     """Get algorithms in the s3 buckets.
 
     Args:
@@ -182,13 +219,16 @@ def get_algorithm_subdirectories_with_s3(prefix: Optional[str] = None) -> Set[st
     Returns:
         Set: set of available algorithms on s3 with that prefix.
     """
+    if module not in gt4sd_configuration_instance.gt4sd_s3_modules:
+        raise KeyError(f"Unknown submodule {module}")
+
     try:
         # directories in the read-only public bucket
         dirs = get_algorithm_subdirectories_from_s3_coordinates(
             host=gt4sd_configuration_instance.gt4sd_s3_host,
             access_key=gt4sd_configuration_instance.gt4sd_s3_access_key,
             secret_key=gt4sd_configuration_instance.gt4sd_s3_secret_key,
-            bucket=gt4sd_configuration_instance.gt4sd_s3_bucket,
+            bucket=gt4sd_configuration_instance.get_s3_bucket[module],
             secure=gt4sd_configuration_instance.gt4sd_s3_secure,
             prefix=prefix,
         )
@@ -198,7 +238,7 @@ def get_algorithm_subdirectories_with_s3(prefix: Optional[str] = None) -> Set[st
             host=gt4sd_configuration_instance.gt4sd_s3_host_hub,
             access_key=gt4sd_configuration_instance.gt4sd_s3_access_key_hub,
             secret_key=gt4sd_configuration_instance.gt4sd_s3_secret_key_hub,
-            bucket=gt4sd_configuration_instance.gt4sd_s3_bucket_hub,
+            bucket=gt4sd_configuration_instance.get_s3_bucket_hub[module],
             secure=gt4sd_configuration_instance.gt4sd_s3_secure_hub,
             prefix=prefix,
         )
@@ -215,16 +255,19 @@ def get_algorithm_subdirectories_with_s3(prefix: Optional[str] = None) -> Set[st
         )
 
 
-def get_algorithm_subdirectories_in_cache(prefix: Optional[str] = None) -> Set[str]:
+def get_algorithm_subdirectories_in_cache(
+    prefix: Optional[str] = None, module: str = "algorithms"
+) -> Set[str]:
     """Get algorithm subdirectories from the cache.
 
     Args:
         prefix: prefix matching cache subdirectories. Defaults to None.
+        module: the submodule that acts as a root for the bucket.
 
     Returns:
         a set of subdirectories.
     """
-    path = get_cached_algorithm_path(prefix=prefix)
+    path = get_cached_algorithm_path(prefix=prefix, module=module)
     try:
         _, dirs, _ = next(iter(os.walk(path)))
         return set(dirs)

--- a/src/gt4sd/configuration.py
+++ b/src/gt4sd/configuration.py
@@ -176,7 +176,7 @@ def get_cached_algorithm_path(
 ) -> str:
 
     if module not in gt4sd_configuration_instance.gt4sd_s3_modules:
-        raise KeyError(f"Unknown submodule {module}")
+        raise ValueError(f"Unknown cache module: {module}. Supported module: {','.join(gt4sd_configuration_instance.gt4sd_s3_modules)}")
 
     return (
         os.path.join(

--- a/src/gt4sd/properties/core.py
+++ b/src/gt4sd/properties/core.py
@@ -21,11 +21,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
+from enum import Enum
 from typing import Any, Callable, Dict, Union
 
 from pydantic import BaseModel, Field
 
 PropertyValue = Union[float, int, Dict[str, Any]]
+
+
+class DomainSubmodule(str, Enum):
+    molecules: str = "molecules"
+    properties: str = "properties"
 
 
 class PropertyPredictorParameters(BaseModel):
@@ -39,7 +45,7 @@ class S3Parameters(PropertyPredictorParameters):
 
     algorithm_type: str = "prediction"
 
-    domain: str = Field(
+    domain: DomainSubmodule = Field(
         ..., example="molecules", description="Submodule of gt4sd.properties"
     )
     algorithm_name: str = Field(..., example="MCA", description="Name of the algorithm")

--- a/src/gt4sd/properties/core.py
+++ b/src/gt4sd/properties/core.py
@@ -23,7 +23,7 @@
 #
 from typing import Any, Callable, Dict, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 PropertyValue = Union[float, int, Dict[str, Any]]
 
@@ -32,6 +32,21 @@ class PropertyPredictorParameters(BaseModel):
     """Abstract class for property computation."""
 
     pass
+
+
+# Base class for property predictors that use S3 artifacts
+class S3Parameters(PropertyPredictorParameters):
+
+    algorithm_type: str = "prediction"
+
+    domain: str = Field(
+        ..., example="molecules", description="Submodule of gt4sd.properties"
+    )
+    algorithm_name: str = Field(..., example="MCA", description="Name of the algorithm")
+    algorithm_version: str = Field(
+        ..., example="v0", description="Version of the algorithm"
+    )
+    algorithm_application: str = Field(..., example="Tox21")
 
 
 class PropertyPredictor:

--- a/src/gt4sd/properties/molecules/__init__.py
+++ b/src/gt4sd/properties/molecules/__init__.py
@@ -21,13 +21,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-from typing import Dict, Tuple, Type
+from typing import Dict, Tuple, Type, Union
 
+from ...algorithms.core import PredictorAlgorithm
 from ..core import PropertyPredictor, PropertyPredictorParameters
 from .core import (
+    SIDER,
     ActivityAgainstTarget,
     ActivityAgainstTargetParameters,
     Bertz,
+    ClinTox,
+    ClinToxParameters,
     Esol,
     IsScaffold,
     Lipinski,
@@ -42,19 +46,28 @@ from .core import (
     NumberRings,
     NumberRotatableBonds,
     NumberStereocenters,
+    OrganTox,
+    OrganToxParameters,
     Plogp,
     Qed,
     Sas,
     Scscore,
     ScscoreConfiguration,
+    SiderParameters,
     SimilaritySeed,
     SimilaritySeedParameters,
+    Tox21,
+    Tox21Parameters,
     Tpsa,
 )
 
 # NOTE: all functions can be called with either a SMILES or a rdkit.Chem.Mol object.
 MOLECULE_PROPERTY_PREDICTOR_FACTORY: Dict[
-    str, Tuple[Type[PropertyPredictor], Type[PropertyPredictorParameters]]
+    str,
+    Tuple[
+        Union[Type[PropertyPredictor], Type[PredictorAlgorithm]],
+        Type[PropertyPredictorParameters],
+    ],
 ] = {
     # inherent properties
     "molecular_weight": (MolecularWeight, PropertyPredictorParameters),
@@ -82,4 +95,8 @@ MOLECULE_PROPERTY_PREDICTOR_FACTORY: Dict[
     # properties predicted by models
     "scscore": (Scscore, ScscoreConfiguration),
     "activity_against_target": (ActivityAgainstTarget, ActivityAgainstTargetParameters),
+    "tox21": (Tox21, Tox21Parameters),
+    "sider": (SIDER, SiderParameters),
+    "organtox": (OrganTox, OrganToxParameters),
+    "clintox": (ClinTox, ClinToxParameters),
 }

--- a/src/gt4sd/properties/molecules/core.py
+++ b/src/gt4sd/properties/molecules/core.py
@@ -21,11 +21,28 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
+from typing import List
+
+from paccmann_generator.drug_evaluators import SIDER as _SIDER
+from paccmann_generator.drug_evaluators import ClinTox as _ClinTox
+from paccmann_generator.drug_evaluators import OrganDB as _OrganTox
 from paccmann_generator.drug_evaluators import SCScore
+from paccmann_generator.drug_evaluators import Tox21 as _Tox21
 from pydantic import Field
 
-from ..core import CallablePropertyPredictor, PropertyPredictorParameters
-from ..utils import get_activity_fn, get_similarity_fn
+from ...algorithms.core import (
+    ConfigurablePropertyAlgorithmConfiguration,
+    Predictor,
+    PredictorAlgorithm,
+)
+from ...domains.materials import SmallMolecule
+from ..core import (
+    CallablePropertyPredictor,
+    PropertyPredictorParameters,
+    PropertyValue,
+    S3Parameters,
+)
+from ..utils import get_activity_fn, get_similarity_fn, to_smiles
 from .functions import (
     bertz,
     esol,
@@ -63,6 +80,66 @@ class SimilaritySeedParameters(PropertyPredictorParameters):
 
 class ActivityAgainstTargetParameters(PropertyPredictorParameters):
     target: str = Field(..., example="drd2", description="name of the target.")
+
+
+class S3ParametersMolecules(S3Parameters):
+    domain: str = "molecules"
+
+
+class MCAParameters(S3ParametersMolecules):
+    algorithm_name: str = "MCA"
+    # algorithm_application: str = Field(
+    #     ..., example='Tox21', description='Name of the application', options=['Tox21']
+    # )
+
+
+class Tox21Parameters(MCAParameters):
+    algorithm_application: str = "Tox21"
+
+
+class ClinToxParameters(MCAParameters):
+    algorithm_application: str = "ClinTox"
+
+
+class SiderParameters(MCAParameters):
+    algorithm_application: str = "SIDER"
+
+
+class OrganToxParameters(MCAParameters):
+    algorithm_application: str = "OrganTox"
+    site: str = Field(
+        ...,
+        example="breast",
+        description="name of the target site of interest.",
+        options=[
+            "Adrenal Gland",
+            "Bone Marrow",
+            "Brain",
+            "Eye",
+            "Heart",
+            "Kidney",
+            "Liver",
+            "Lung",
+            "Lymph Node",
+            "Mammary Gland",
+            "Pancreas",
+            "Pituitary Gland",
+            "Spleen",
+            "Stomach",
+            "Testes",
+            "Thymus",
+            "Thyroid Gland",
+            "Urinary Bladder",
+            "Uterus",
+            "Ovary",
+        ],
+    )
+    toxicity_type: str = Field(
+        default="all",
+        example="chronic",
+        description="type of toxicity for which predictions are made.",
+        options=["chronic", "subchronic", "multigenerational", "all"],
+    )
 
 
 # NOTE: property prediction classes
@@ -271,3 +348,181 @@ class ActivityAgainstTarget(CallablePropertyPredictor):
         super().__init__(
             callable_fn=get_activity_fn(target=parameters.target), parameters=parameters
         )
+
+
+class _MCA(PredictorAlgorithm):
+    """Base class for all MCA-based predictive algorithms."""
+
+    def __init__(self, parameters: MCAParameters):
+
+        # Set up the configuration from the parameters
+        configuration = ConfigurablePropertyAlgorithmConfiguration(
+            algorithm_type=parameters.algorithm_type,
+            domain=parameters.domain,
+            algorithm_name=parameters.algorithm_name,
+            algorithm_application=parameters.algorithm_application,
+            algorithm_version=parameters.algorithm_version,
+        )
+
+        # The parent constructor calls `self.get_model`.
+        super().__init__(configuration=configuration)
+
+
+class Tox21(_MCA):
+    """Model to predict environmental toxicity for the 12 endpoints in Tox21."""
+
+    def __init__(self, parameters: Tox21Parameters) -> None:
+
+        super().__init__(parameters=parameters)
+
+    def get_model(self, resources_path: str) -> Predictor:
+        """Instantiate the actual model.
+
+        Args:
+            resources_path: local path to model files.
+
+        Returns:
+            Predictor: the model.
+        """
+        # This model returns a singular reward and not a prediction for all 12 classes.
+        model = _Tox21(model_path=resources_path)
+
+        # Wrapper to get toxicity-endpoint-level predictions
+        def informative_model(x: SmallMolecule) -> List[PropertyValue]:
+            x = to_smiles(x)
+            _ = model(x)
+            return model.predictions.detach().tolist()
+
+        return informative_model
+
+    @classmethod
+    def get_description(cls) -> str:
+        text = """
+        This model predicts the 12 endpoints from the Tox21 challenge.
+        The endpoints are: NR-AR, NR-AR-LBD, NR-AhR, NR-Aromatase, NR-ER, NR-ER-LBD, NR-PPAR-gamma, SR-ARE, SR-ATAD5, SR-HSE, SR-MMP, SR-p53
+        For details on the data see: https://tripod.nih.gov/tox21/challenge/.
+        """
+        return text
+
+
+class ClinTox(_MCA):
+    """Model to predict environmental toxicity for the 12 endpoints in Tox21."""
+
+    def __init__(self, parameters: ClinToxParameters) -> None:
+
+        super().__init__(parameters=parameters)
+
+    def get_model(self, resources_path: str) -> Predictor:
+        """Instantiate the actual model.
+
+        Args:
+            resources_path: local path to model files.
+
+        Returns:
+            Predictor: the model.
+        """
+        # This model returns a singular reward and not a prediction for both classes.
+        model = _ClinTox(model_path=resources_path)
+
+        # Wrapper to get toxicity-endpoint-level predictions
+        def informative_model(x: SmallMolecule) -> List[PropertyValue]:
+            x = to_smiles(x)
+            _ = model(x)
+            return model.predictions.detach().tolist()
+
+        return informative_model
+
+    @classmethod
+    def get_description(cls) -> str:
+        text = """
+        This model is a multitask classifier for two classes:
+            1. Predicted probability to receive FDA approval.
+            2. Predicted probability of failure in clinical trials.
+        For details on the data see: https://pubs.rsc.org/en/content/articlehtml/2018/sc/c7sc02664a.
+        """
+        return text
+
+
+class SIDER(_MCA):
+    def __init__(self, parameters: SiderParameters) -> None:
+
+        super().__init__(parameters=parameters)
+
+    def get_model(self, resources_path: str) -> Predictor:
+        """Instantiate the actual model.
+
+        Args:
+            resources_path: local path to model files.
+
+        Returns:
+            Predictor: the model.
+        """
+        # This model returns a singular reward and not a prediction for both classes.
+        model = _SIDER(model_path=resources_path)
+
+        # Wrapper to get toxicity-endpoint-level predictions
+        def informative_model(x: SmallMolecule) -> List[PropertyValue]:
+            x = to_smiles(x)
+            _ = model(x)
+            return model.predictions.detach().tolist()
+
+        return informative_model
+
+    @classmethod
+    def get_description(cls) -> str:
+        text = """
+        This model is a multitask classifier to predict side effects of drugs across
+        27 classes. For details on the data see:
+        https://pubs.rsc.org/en/content/articlehtml/2018/sc/c7sc02664a.
+        """
+        return text
+
+
+class OrganTox(_MCA):
+    """Model to predict toxicity for different organs."""
+
+    def __init__(self, parameters: OrganToxParameters) -> None:
+
+        # Extract model-specific parameters
+        self.site = parameters.site
+        self.toxicity_type = parameters.toxicity_type
+
+        super().__init__(parameters=parameters)
+
+    def get_model(self, resources_path: str) -> Predictor:
+        """Instantiate the actual model.
+
+        Args:
+            resources_path: local path to model files.
+
+        Returns:
+            Predictor: the model.
+        """
+        # This model returns a singular reward and not a prediction for both classes.
+        model = _OrganTox(
+            model_path=resources_path, site=self.site, toxicity_type=self.toxicity_type
+        )
+
+        # Wrapper to get toxicity-endpoint-level predictions
+        def informative_model(x: SmallMolecule) -> List[PropertyValue]:
+            x = to_smiles(x)
+            _ = model(x)
+            all_preds = model.predictions.detach()[model.class_indices]
+
+            return all_preds[model.class_indices].tolist()
+
+        return informative_model
+
+    @classmethod
+    def get_description(cls) -> str:
+        text = """
+        This model is a multitask classifier to toxicity across different organs and
+        toxicity types (`chronic`, `subchronic`, `multigenerational` or `all`).
+        The organ has to specified in the constructor. The toxicity type defaults to
+        `all` in which case three values are returned in the order `chronic`,
+        `multigenerational` and `subchronic`.
+
+        For details on the data see:
+        https://pubs.rsc.org/en/content/articlehtml/2018/sc/c7sc02664a.
+        """
+        return text

--- a/src/gt4sd/properties/molecules/core.py
+++ b/src/gt4sd/properties/molecules/core.py
@@ -88,9 +88,6 @@ class S3ParametersMolecules(S3Parameters):
 
 class MCAParameters(S3ParametersMolecules):
     algorithm_name: str = "MCA"
-    # algorithm_application: str = Field(
-    #     ..., example='Tox21', description='Name of the application', options=['Tox21']
-    # )
 
 
 class Tox21Parameters(MCAParameters):
@@ -371,10 +368,6 @@ class _MCA(PredictorAlgorithm):
 class Tox21(_MCA):
     """Model to predict environmental toxicity for the 12 endpoints in Tox21."""
 
-    def __init__(self, parameters: Tox21Parameters) -> None:
-
-        super().__init__(parameters=parameters)
-
     def get_model(self, resources_path: str) -> Predictor:
         """Instantiate the actual model.
 
@@ -408,10 +401,6 @@ class Tox21(_MCA):
 class ClinTox(_MCA):
     """Model to predict environmental toxicity for the 12 endpoints in Tox21."""
 
-    def __init__(self, parameters: ClinToxParameters) -> None:
-
-        super().__init__(parameters=parameters)
-
     def get_model(self, resources_path: str) -> Predictor:
         """Instantiate the actual model.
 
@@ -444,10 +433,6 @@ class ClinTox(_MCA):
 
 
 class SIDER(_MCA):
-    def __init__(self, parameters: SiderParameters) -> None:
-
-        super().__init__(parameters=parameters)
-
     def get_model(self, resources_path: str) -> Predictor:
         """Instantiate the actual model.
 
@@ -507,7 +492,7 @@ class OrganTox(_MCA):
         def informative_model(x: SmallMolecule) -> List[PropertyValue]:
             x = to_smiles(x)
             _ = model(x)
-            all_preds = model.predictions.detach()[model.class_indices]
+            all_preds = model.predictions.detach()
 
             return all_preds[model.class_indices].tolist()
 

--- a/src/gt4sd/properties/molecules/core.py
+++ b/src/gt4sd/properties/molecules/core.py
@@ -21,6 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
+from enum import Enum
 from typing import List
 
 from paccmann_generator.drug_evaluators import SIDER as _SIDER
@@ -38,6 +39,7 @@ from ...algorithms.core import (
 from ...domains.materials import SmallMolecule
 from ..core import (
     CallablePropertyPredictor,
+    DomainSubmodule,
     PropertyPredictorParameters,
     PropertyValue,
     S3Parameters,
@@ -83,7 +85,7 @@ class ActivityAgainstTargetParameters(PropertyPredictorParameters):
 
 
 class S3ParametersMolecules(S3Parameters):
-    domain: str = "molecules"
+    domain: DomainSubmodule = DomainSubmodule("molecules")
 
 
 class MCAParameters(S3ParametersMolecules):
@@ -103,35 +105,41 @@ class SiderParameters(MCAParameters):
 
 
 class OrganToxParameters(MCAParameters):
+    class Organs(str, Enum):
+        adrenal_gland: str = "Adrenal Gland"
+        bone_marrow: str = "Bone Marrow"
+        brain: str = "Brain"
+        eye: str = "Eye"
+        heart: str = "Heart"
+        kidney: str = "Kidney"
+        liver: str = "Liver"
+        lung: str = "Lung"
+        lymph_node: str = "Lymph Node"
+        mammary_gland: str = "Mammary Gland"
+        ovary: str = "Ovary"
+        pancreas: str = "Pancreas"
+        pituitary_gland: str = "Pituitary Gland"
+        spleen: str = "Spleen"
+        stomach: str = "Stomach"
+        testes: str = "Testes"
+        thymus: str = "Thymus"
+        thyroid_gland: str = "Thyroid Gland"
+        urinary_bladder: str = "Urinary Bladder"
+        uterus: str = "Uterus"
+
+    class ToxType(str, Enum):
+        chronic: str = "chronic"
+        subchronic: str = "subchronic"
+        multigenerational: str = "multigenerational"
+        all: str = "all"
+
     algorithm_application: str = "OrganTox"
-    site: str = Field(
+    site: Organs = Field(
         ...,
         example="breast",
         description="name of the target site of interest.",
-        options=[
-            "Adrenal Gland",
-            "Bone Marrow",
-            "Brain",
-            "Eye",
-            "Heart",
-            "Kidney",
-            "Liver",
-            "Lung",
-            "Lymph Node",
-            "Mammary Gland",
-            "Pancreas",
-            "Pituitary Gland",
-            "Spleen",
-            "Stomach",
-            "Testes",
-            "Thymus",
-            "Thyroid Gland",
-            "Urinary Bladder",
-            "Uterus",
-            "Ovary",
-        ],
     )
-    toxicity_type: str = Field(
+    toxicity_type: ToxType = Field(
         default="all",
         example="chronic",
         description="type of toxicity for which predictions are made.",

--- a/src/gt4sd/properties/molecules/functions.py
+++ b/src/gt4sd/properties/molecules/functions.py
@@ -37,7 +37,7 @@ from guacamol.utils.descriptors import (
 )
 from guacamol.utils.descriptors import qed as _qed
 from guacamol.utils.descriptors import tpsa as _tpsa
-from paccmann_generator.drug_evaluators import (  # SIDER,; ClinTox,; OrganDB,; Tox21,
+from paccmann_generator.drug_evaluators import (
     ESOL,
     SAS,
     Lipinski,

--- a/src/gt4sd/properties/tests/__init__.py
+++ b/src/gt4sd/properties/tests/__init__.py
@@ -1,0 +1,23 @@
+#
+# MIT License
+#
+# Copyright (c) 2022 GT4SD team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/src/gt4sd/properties/tests/test_properties.py
+++ b/src/gt4sd/properties/tests/test_properties.py
@@ -74,21 +74,32 @@ molecule_further_ground_truths = {
 }
 protein_further_ground_truths = {"charge": 1.123}
 
-artifact_model_ground_truths = {
-    "tox21": [
-        6.422001024475321e-05,
-        0.00028556393226608634,
-        0.0027144483756273985,
-        0.03775344416499138,
-        0.000604992441367358,
-        0.00027705798856914043,
-        0.10752066224813461,
-        0.5733309388160706,
-        0.001268531079404056,
-        0.10181115567684174,
-        0.8995946049690247,
-        0.1677667647600174,
-    ],
+artifact_model_data = {
+    "tox21": {
+        "parameters": {"algorithm_version": "v0"},
+        "ground_truth": [
+            6.422001024475321e-05,
+            0.00028556393226608634,
+            0.0027144483756273985,
+            0.03775344416499138,
+            0.000604992441367358,
+            0.00027705798856914043,
+            0.10752066224813461,
+            0.5733309388160706,
+            0.001268531079404056,
+            0.10181115567684174,
+            0.8995946049690247,
+            0.1677667647600174,
+        ],
+    },
+    "organtox": {
+        "parameters": {
+            "algorithm_version": "v0",
+            "site": "Heart",
+            "toxicity_type": "all",
+        },
+        "ground_truth": [0.06142323836684227, 0.07934761792421341],
+    },
 }
 
 
@@ -130,15 +141,19 @@ def test_charge_with_arguments():
 
 @pytest.mark.parametrize(
     "property_key",
-    [(property_key) for property_key in artifact_model_ground_truths.keys()],
+    [(property_key) for property_key in artifact_model_data.keys()],
 )
 def test_artifact_models(property_key):
     property_class, parameters_class = PROPERTY_PREDICTOR_FACTORY[property_key]
-    function = property_class(parameters_class(algorithm_version="v0"))
+    function = property_class(
+        parameters_class(**artifact_model_data[property_key]["parameters"])
+    )
     sample = protein if property_key in PROTEIN_PROPERTY_PREDICTOR_FACTORY else molecule
     assert all(
         np.isclose(
-            function(sample), artifact_model_ground_truths[property_key], atol=1e-2
+            function(sample),
+            artifact_model_data[property_key]["ground_truth"],
+            atol=1e-2,
         )
     )  # type: ignore
 

--- a/src/gt4sd/properties/tests/test_properties.py
+++ b/src/gt4sd/properties/tests/test_properties.py
@@ -152,7 +152,7 @@ def test_artifact_models(property_key):
     assert all(
         np.isclose(
             function(sample),
-            artifact_model_data[property_key]["ground_truth"],
+            artifact_model_data[property_key]["ground_truth"],  # type: ignore
             atol=1e-2,
         )
     )  # type: ignore

--- a/src/gt4sd/properties/tests/test_properties.py
+++ b/src/gt4sd/properties/tests/test_properties.py
@@ -74,6 +74,23 @@ molecule_further_ground_truths = {
 }
 protein_further_ground_truths = {"charge": 1.123}
 
+artifact_model_ground_truths = {
+    "tox21": [
+        6.422001024475321e-05,
+        0.00028556393226608634,
+        0.0027144483756273985,
+        0.03775344416499138,
+        0.000604992441367358,
+        0.00027705798856914043,
+        0.10752066224813461,
+        0.5733309388160706,
+        0.001268531079404056,
+        0.10181115567684174,
+        0.8995946049690247,
+        0.1677667647600174,
+    ],
+}
+
 
 @pytest.mark.parametrize(
     "property_key", [(property_key) for property_key in ground_truths.keys()]
@@ -82,16 +99,16 @@ def test_property(property_key):
     property_class, parameters_class = PROPERTY_PREDICTOR_FACTORY[property_key]
     function = property_class(parameters_class())
     sample = protein if property_key in PROTEIN_PROPERTY_PREDICTOR_FACTORY else molecule
-    assert np.isclose(function(sample), ground_truths[property_key])  # type: ignore
+    assert np.isclose(function(sample), ground_truths[property_key], atol=1e-2)  # type: ignore
 
 
 def test_similarity_seed():
     property_class, parameters_class = MOLECULE_PROPERTY_PREDICTOR_FACTORY[
         "similarity_seed"
     ]
-    function = property_class(parameters_class(smiles=seed))
+    function = property_class(parameters_class(smiles=seed))  # type: ignore
     assert np.isclose(
-        function(molecule), molecule_further_ground_truths["similarity_seed"]  # type: ignore
+        function(molecule), molecule_further_ground_truths["similarity_seed"], atol=1e-2  # type: ignore
     )
 
 
@@ -99,16 +116,31 @@ def test_activity_against_target():
     property_class, parameters_class = MOLECULE_PROPERTY_PREDICTOR_FACTORY[
         "activity_against_target"
     ]
-    function = property_class(parameters_class(target=target))
+    function = property_class(parameters_class(target=target))  # type: ignore
     assert np.isclose(
-        function(molecule), molecule_further_ground_truths["activity_against_target"]  # type: ignore
+        function(molecule), molecule_further_ground_truths["activity_against_target"], atol=1e-2  # type: ignore
     )
 
 
 def test_charge_with_arguments():
     property_class, parameters_class = PROTEIN_PROPERTY_PREDICTOR_FACTORY["charge"]
     function = property_class(parameters_class(amide=True, ph=5.0))
-    assert np.isclose(function(protein), protein_further_ground_truths["charge"])  # type: ignore
+    assert np.isclose(function(protein), protein_further_ground_truths["charge"], atol=1e-2)  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "property_key",
+    [(property_key) for property_key in artifact_model_ground_truths.keys()],
+)
+def test_artifact_models(property_key):
+    property_class, parameters_class = PROPERTY_PREDICTOR_FACTORY[property_key]
+    function = property_class(parameters_class(algorithm_version="v0"))
+    sample = protein if property_key in PROTEIN_PROPERTY_PREDICTOR_FACTORY else molecule
+    assert all(
+        np.isclose(
+            function(sample), artifact_model_ground_truths[property_key], atol=1e-2
+        )
+    )  # type: ignore
 
 
 def test_property_predictor_registry():

--- a/src/gt4sd/training_pipelines/regression_transformer/utils.py
+++ b/src/gt4sd/training_pipelines/regression_transformer/utils.py
@@ -256,6 +256,81 @@ class TransformersTrainingArgumentsCLI(TrainingArguments):
             )
         },
     )
+    evaluation_strategy: Optional[str] = field(  # type: ignore
+        default="no",
+        metadata={
+            "help": (
+                "The evaluation strategy to adopt during training. Possible values are:"
+                " - 'no': No evaluation is done during training."
+                " - 'steps'`: Evaluation is done (and logged) every `eval_steps`."
+                " - 'epoch': Evaluation is done at the end of each epoch."
+            )
+        },
+    )
+    lr_scheduler_type: Optional[str] = field(  # type: ignore
+        default="linear",
+        metadata={
+            "help": (
+                "The scheduler type to use. See the documentation of "
+                "`transformers.SchedulerType` for all possible values."
+            )
+        },
+    )
+    logging_strategy: Optional[str] = field(  # type: ignore
+        default="steps",
+        metadata={
+            "help": (
+                "The logging strategy to adopt during training. Possible values are:"
+                " - 'no': No logging is done during training."
+                " - 'steps'`: Logging is done every `logging_steps`."
+                " - 'epoch': Logging is done at the end of each epoch."
+            )
+        },
+    )
+    save_strategy: Optional[str] = field(  # type: ignore
+        default="steps",
+        metadata={
+            "help": (
+                "The saving strategy to adopt during training. Possible values are:"
+                " - 'no': No saving is done during training."
+                " - 'steps'`: Saving is done every `saving_steps`."
+                " - 'epoch': Saving is done at the end of each epoch."
+            )
+        },
+    )
+    hub_strategy: Optional[str] = field(  # type: ignore
+        default="every_save",
+        metadata={
+            "help": (
+                "Optional, defaults to `every_save`. Defines the scope of what is pushed "
+                "to the Hub and when. Possible values are:"
+                " - `end`: push the model, its configuration, the tokenizer (if passed "
+                "       along to the Trainer and a draft of a model card when the "
+                "       Trainer.save_model method is called."
+                " - `every_save`: push the model, its configuration, the tokenizer (if "
+                "       passed along to the Trainer and a draft of a model card each time "
+                "       there is a model save. The pushes are asynchronous to not block "
+                "       training, and in case the save are very frequent, a new push is "
+                "       only attempted if the previous one is finished. A last push is made "
+                "       with the final model at the end of training."
+                " - `checkpoint`: like `every_save` but the latest checkpoint is also "
+                "       pushed in a subfolder named last-checkpoint, allowing you to resume "
+                "       training easily with `trainer.train(resume_from_checkpoint)`."
+                " - `all_checkpoints`: like `checkpoint` but all checkpoints are pushed "
+                "       like they appear in the output folder (so you will get one "
+                "       checkpoint folder per folder in your final repository)."
+            )
+        },
+    )
+    optim: Optional[str] = field(  # type: ignore
+        default="adamw_hf",
+        metadata={
+            "help": (
+                "The optimizer to use. One of  `adamw_hf`, `adamw_torch`, `adafactor` "
+                "or `adamw_apex_fused`."
+            )
+        },
+    )
 
     def __post_init__(self):
         """


### PR DESCRIPTION
Closes #116

Now we can store artifacts also for property predictors

- New property predictors are tested 
- One thing that remains to do is to have functions under `gt4sd.properties.molecules.functions`. Atm this is not yet supported since it would yield circular imports. 