### PR TITLE
feat: configurable unverified contexts for SSL.

### DIFF
--- a/src/gt4sd/__init__.py
+++ b/src/gt4sd/__init__.py
@@ -25,3 +25,13 @@
 
 __version__ = "0.47.0"
 __name__ = "gt4sd"
+
+# NOTE: configure SSL to allow unverified contexts by default
+from .configuration import GT4SDConfiguration
+
+gt4sd_configuration_instance = GT4SDConfiguration.get_instance()
+
+if gt4sd_configuration_instance.gt4sd_create_unverified_ssl_context:
+    import ssl
+
+    ssl._create_default_https_context = ssl._create_unverified_context

--- a/src/gt4sd/configuration.py
+++ b/src/gt4sd/configuration.py
@@ -49,6 +49,7 @@ class GT4SDConfiguration(BaseSettings):
     gt4sd_max_number_of_stuck_calls: int = 50
     gt4sd_max_number_of_samples: int = 1000000
     gt4sd_max_runtime: int = 86400
+    gt4sd_create_unverified_ssl_context: bool = False
 
     gt4sd_s3_host: str = "s3.par01.cloud-object-storage.appdomain.cloud"
     gt4sd_s3_access_key: str = "6e9891531d724da89997575a65f4592e"


### PR DESCRIPTION
Signed-off-by: Matteo Manica <drugilsberg@gmail.com>

Allow to create unverified SSL contexts. This can be useful when using gt4sd properties predictors inside containers where it can be non trivial to verify local certificates to download prediction model artifacts.