### PR TITLE
TDC Oracle integration

### DIFF
--- a/examples/regression_transformer/README.md
+++ b/examples/regression_transformer/README.md
@@ -11,7 +11,7 @@ conda activate gt4sd
 To launch a finetuning of a RT pretrained on drug-like moelcules from ChEMBL, execute the following from the GT4SD root:
 
 ```console
- gt4sd-trainer --training_pipeline_name regression-transformer-trainer --model_path ~/.gt4sd/algorithms/conditional_generation/RegressionTransformer/RegressionTransformerMolecules/qed --do_train --output_dir dummy_regression_transformer --train_data_path src/gt4sd/training_pipelines/tests/regression_transformer_raw.csv --test_data_path src/gt4sd/training_pipelines/tests/regression_transformer_raw.csv --overwrite_output_dir --eval_steps 2 --augment 10 --test_fraction 0.2 --eval_accumulation_steps 1
+ gt4sd-trainer --training_pipeline_name regression-transformer-trainer --model_path ~/.gt4sd/algorithms/conditional_generation/RegressionTransformer/RegressionTransformerMolecules/qed --do_train --output_dir dummy_regression_transformer --train_data_path src/gt4sd/training_pipelines/tests/regression_transformer_raw.csv --test_data_path src/gt4sd/training_pipelines/tests/regression_transformer_raw.csv --overwrite_output_dir --eval_steps 2 --augment 10 --eval_accumulation_steps 1
 ```
 *NOTE*: This is *dummy* example, do not use "as is" :warning:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 accelerate>=0.12
 datasets>=1.11.0
 diffusers>=0.2.4
+ipaddress>=1.0.23
 joblib>=1.1.0
 keras==2.3.1
 keybert==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,13 +11,13 @@ numpy>=1.16.5
 protobuf<3.20
 pytorch_lightning<=1.5.0
 pydantic>=1.7.3,<=1.9.2
-PyTDC>=0.3.6
+PyTDC>=0.3.7
 pyyaml>=5.4.1
 rdkit-pypi>=2020.9.5.2,<=2021.9.4
 regex>=2.5.91
 reinvent-chemistry==0.0.38
 sacremoses>=0.0.41
-scikit-learn<0.24.0
+scikit-learn>=1.0.0
 scikit-optimize>=0.8.1
 sentencepiece>=0.1.95
 sympy>=1.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ torchvision>=0.12.0
 transformers>=4.2.1
 typing_extensions>=3.7.4.3
 wheel>=0.26
+importlib-metadata<5.0.0 # temporary: https://github.com/python/importlib_metadata/issues/409

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires =
     accelerate
     datasets
     diffusers
+    ipaddress
     joblib
     keras
     keybert

--- a/setup.cfg
+++ b/setup.cfg
@@ -230,3 +230,12 @@ ignore_missing_imports = True
 
 [mypy-sympy.*]
 ignore_missing_imports = True
+
+[mypy-openbabel.*]
+ignore_missing_imports = True
+
+[mypy-pyscreener.*]
+ignore_missing_imports = True
+
+[mypy-pdbfixer.*]
+ignore_missing_imports = True

--- a/src/gt4sd/properties/core.py
+++ b/src/gt4sd/properties/core.py
@@ -55,6 +55,23 @@ class S3Parameters(PropertyPredictorParameters):
     algorithm_application: str = Field(..., example="Tox21")
 
 
+class ApiTokenParameters(PropertyPredictorParameters):
+    api_token: str = Field(
+        ...,
+        example="apk-c9db......",
+        description="The API token/key to access the service",
+    )
+
+
+class IpAdressParameters(PropertyPredictorParameters):
+
+    host_ip: str = Field(
+        ...,
+        example="xx.xx.xxx.xxx",
+        description="The host IP address to access the service",
+    )
+
+
 class PropertyPredictor:
     """PropertyPredictor base class."""
 

--- a/src/gt4sd/properties/molecules/__init__.py
+++ b/src/gt4sd/properties/molecules/__init__.py
@@ -26,9 +26,10 @@ from typing import Dict, Tuple, Type, Union
 from ...algorithms.core import PredictorAlgorithm
 from ..core import PropertyPredictor, PropertyPredictorParameters
 from .core import (
-    SIDER,
     ActivityAgainstTarget,
     ActivityAgainstTargetParameters,
+    Askcos,
+    AskcosParameters,
     Bertz,
     ClinTox,
     ClinToxParameters,
@@ -37,6 +38,8 @@ from .core import (
     Lipinski,
     Logp,
     MolecularWeight,
+    MoleculeOne,
+    MoleculeOneParameters,
     NumberAromaticRings,
     NumberAtoms,
     NumberHAcceptors,
@@ -53,6 +56,7 @@ from .core import (
     Sas,
     Scscore,
     ScscoreConfiguration,
+    Sider,
     SiderParameters,
     SimilaritySeed,
     SimilaritySeedParameters,
@@ -96,9 +100,12 @@ MOLECULE_PROPERTY_PREDICTOR_FACTORY: Dict[
     "scscore": (Scscore, ScscoreConfiguration),
     "activity_against_target": (ActivityAgainstTarget, ActivityAgainstTargetParameters),
     "tox21": (Tox21, Tox21Parameters),
-    "sider": (SIDER, SiderParameters),
+    "sider": (Sider, SiderParameters),
     "organtox": (OrganTox, OrganToxParameters),
     "clintox": (ClinTox, ClinToxParameters),
+    # properties from models requiring authentification
+    "askcos": (Askcos, AskcosParameters),
+    "molecule_one": (MoleculeOne, MoleculeOneParameters),
 }
 
 

--- a/src/gt4sd/properties/molecules/__init__.py
+++ b/src/gt4sd/properties/molecules/__init__.py
@@ -33,6 +33,10 @@ from .core import (
     Bertz,
     ClinTox,
     ClinToxParameters,
+    Docking,
+    DockingParameters,
+    DockingTdc,
+    DockingTdcParameters,
     Esol,
     IsScaffold,
     Lipinski,
@@ -103,9 +107,12 @@ MOLECULE_PROPERTY_PREDICTOR_FACTORY: Dict[
     "sider": (Sider, SiderParameters),
     "organtox": (OrganTox, OrganToxParameters),
     "clintox": (ClinTox, ClinToxParameters),
-    # properties from models requiring authentification
+    # # properties from models requiring authentification
     "askcos": (Askcos, AskcosParameters),
     "molecule_one": (MoleculeOne, MoleculeOneParameters),
+    # # properties from models require additional installations
+    "docking_tdc": (DockingTdc, DockingTdcParameters),
+    "docking": (Docking, DockingParameters),
 }
 
 

--- a/src/gt4sd/properties/molecules/core.py
+++ b/src/gt4sd/properties/molecules/core.py
@@ -50,6 +50,7 @@ from ..core import (
     S3Parameters,
 )
 from ..utils import (
+    docking_import_check,
     get_activity_fn,
     get_similarity_fn,
     to_smiles,
@@ -493,32 +494,12 @@ class DockingTdc(ConfigurableCallablePropertyPredictor):
 
     def __init__(self, parameters: DockingTdcParameters):
 
-        self.import_check()
+        docking_import_check()
         callable = Oracle(name=parameters.target)
         super().__init__(callable_fn=callable, parameters=parameters)
 
-    def import_check(self):
-        """
-        Verifies that __some__ of the required packages for docking are installed.
 
-        Raises:
-            ModuleNotFoundError: _description_
-        """
-        try:
-            import openbabel
-            import pdbfixer
-            import pyscreener
-
-            openbabel, pdbfixer, pyscreener
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError(
-                "You dont seem to have a valid installation for docking. You at "
-                "least need `pdbfixer`, `openbabel` and `pyscreener` installed."
-                "See here for details: https://tdcommons.ai/functions/oracles/#docking-scores"
-            )
-
-
-class Docking(DockingTdc):
+class Docking(ConfigurableCallablePropertyPredictor):
     """
     A property predictor that computes the docking score against a user-defined target.
     Relies on TDC backend, see https://tdcommons.ai/functions/oracles/#docking-scores for setup.
@@ -526,7 +507,7 @@ class Docking(DockingTdc):
 
     def __init__(self, parameters: DockingParameters):
 
-        self.import_check()
+        docking_import_check()
         callable = Oracle(
             name=parameters.name,
             receptor_pdb_file=parameters.receptor_pdb_file,

--- a/src/gt4sd/properties/molecules/core.py
+++ b/src/gt4sd/properties/molecules/core.py
@@ -24,12 +24,13 @@
 from enum import Enum
 from typing import List
 
-from paccmann_generator.drug_evaluators import SIDER as _SIDER
+from paccmann_generator.drug_evaluators import SIDER
 from paccmann_generator.drug_evaluators import ClinTox as _ClinTox
 from paccmann_generator.drug_evaluators import OrganDB as _OrganTox
 from paccmann_generator.drug_evaluators import SCScore
 from paccmann_generator.drug_evaluators import Tox21 as _Tox21
 from pydantic import Field
+from tdc import Oracle
 
 from ...algorithms.core import (
     ConfigurablePropertyAlgorithmConfiguration,
@@ -38,13 +39,22 @@ from ...algorithms.core import (
 )
 from ...domains.materials import SmallMolecule
 from ..core import (
+    ApiTokenParameters,
     CallablePropertyPredictor,
+    ConfigurableCallablePropertyPredictor,
     DomainSubmodule,
+    IpAdressParameters,
     PropertyPredictorParameters,
     PropertyValue,
     S3Parameters,
 )
-from ..utils import get_activity_fn, get_similarity_fn, to_smiles
+from ..utils import (
+    get_activity_fn,
+    get_similarity_fn,
+    to_smiles,
+    validate_api_token,
+    validate_ip,
+)
 from .functions import (
     bertz,
     esol,
@@ -82,6 +92,49 @@ class SimilaritySeedParameters(PropertyPredictorParameters):
 
 class ActivityAgainstTargetParameters(PropertyPredictorParameters):
     target: str = Field(..., example="drd2", description="name of the target.")
+
+
+class AskcosParameters(IpAdressParameters):
+    class Output(str, Enum):
+        plausability: str = "plausibility"
+        num_step: str = "num_step"
+        synthesizability: str = "synthesizability"
+        price: str = "price"
+
+    output: Output = Field(
+        default=Output.plausability,
+        example=Output.synthesizability,
+        description="Main output return type from ASKCOS",
+        options=["plausibility", "num_step", "synthesizability", "price"],
+    )
+    save_json: bool = Field(default=False)
+    file_name: str = Field(default="tree_builder_result.json")
+    num_trials: int = Field(default=5)
+    max_depth: int = Field(default=9)
+    max_branching: int = Field(default=25)
+    expansion_time: int = Field(default=60)
+    max_ppg: int = Field(default=100)
+    template_count: int = Field(default=1000)
+    max_cum_prob: float = Field(default=0.999)
+    chemical_property_logic: str = Field(default="none")
+    max_chemprop_c: int = Field(default=0)
+    max_chemprop_n: int = Field(default=0)
+    max_chemprop_o: int = Field(default=0)
+    max_chemprop_h: int = Field(default=0)
+    chemical_popularity_logic: str = Field(default="none")
+    min_chempop_reactants: int = Field(default=5)
+    min_chempop_products: int = Field(default=5)
+    filter_threshold: float = Field(default=0.1)
+    return_first: str = Field(default="true")
+
+    # Convert enum items back to strings
+    class Config:
+        use_enum_values = True
+
+
+class MoleculeOneParameters(ApiTokenParameters):
+
+    oracle_name: str = "Molecule One Synthesis"
 
 
 class S3ParametersMolecules(S3Parameters):
@@ -355,6 +408,50 @@ class ActivityAgainstTarget(CallablePropertyPredictor):
         )
 
 
+class Askcos(ConfigurableCallablePropertyPredictor):
+    def __init__(self, parameters: AskcosParameters):
+
+        # Raises if IP is not valid
+        msg = (
+            "You have to point to an IP address of a running ASKCOS instance. "
+            "For details on setting this up, see: https://tdcommons.ai/functions/oracles/#askcos"
+        )
+        if not isinstance(parameters.host_ip, str):
+            raise TypeError(f"IP adress must be a string, not {parameters.host_ip}")
+
+        if not hasattr(parameters, "host_ip"):
+            raise AttributeError(f"IP adress missing in {parameters}")
+
+        if not "http" in parameters.host_ip:
+            raise ValueError(
+                f"ASKCOS requires an IP prepended with a http, e.g., "
+                f"'http://xx.xx.xxx.xxx' and not {parameters.host_ip}."
+            )
+        ip = parameters.host_ip.split("//")[1]
+
+        validate_ip(ip, message=msg)
+        super().__init__(callable_fn=Oracle(name="ASKCOS"), parameters=parameters)
+
+
+class MoleculeOne(CallablePropertyPredictor):
+    def __init__(self, parameters: MoleculeOneParameters):
+
+        msg = (
+            "You have to provide a valid API key, for details on setting this up, see: "
+            "https://tdcommons.ai/functions/oracles/#moleculeone"
+        )
+
+        # Only performs type checking on API key
+        validate_api_token(parameters, message=msg)
+
+        super().__init__(
+            callable_fn=Oracle(
+                name=parameters.oracle_name, api_token=parameters.api_token
+            ),
+            parameters=parameters,
+        )
+
+
 class _MCA(PredictorAlgorithm):
     """Base class for all MCA-based predictive algorithms."""
 
@@ -440,7 +537,7 @@ class ClinTox(_MCA):
         return text
 
 
-class SIDER(_MCA):
+class Sider(_MCA):
     def get_model(self, resources_path: str) -> Predictor:
         """Instantiate the actual model.
 
@@ -451,7 +548,7 @@ class SIDER(_MCA):
             Predictor: the model.
         """
         # This model returns a singular reward and not a prediction for both classes.
-        model = _SIDER(model_path=resources_path)
+        model = SIDER(model_path=resources_path)
 
         # Wrapper to get toxicity-endpoint-level predictions
         def informative_model(x: SmallMolecule) -> List[PropertyValue]:

--- a/src/gt4sd/properties/utils.py
+++ b/src/gt4sd/properties/utils.py
@@ -224,3 +224,24 @@ def validate_api_token(parameters: ApiTokenParameters, message: str = "") -> Non
         raise TypeError(
             f"API key has to be a string not {parameters.api_token}\n {message}"
         )
+
+
+def docking_import_check() -> None:
+    """
+    Verifies that __some__ of the required packages for docking are installed.
+
+    Raises:
+        ModuleNotFoundError: If a necessary module was not found.
+    """
+    try:
+        import openbabel
+        import pdbfixer
+        import pyscreener
+
+        openbabel, pdbfixer, pyscreener
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
+            "You dont seem to have a valid installation for docking. You at "
+            "least need `pdbfixer`, `openbabel` and `pyscreener` installed."
+            "See here for details: https://tdcommons.ai/functions/oracles/#docking-scores"
+        )

--- a/src/gt4sd/properties/utils.py
+++ b/src/gt4sd/properties/utils.py
@@ -21,6 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
+import ipaddress
 import json
 from typing import Any, Callable, Dict, List, Tuple, Type, Union
 
@@ -31,7 +32,7 @@ from tdc.chem_utils.oracle.oracle import fp2fpfunc
 from tdc.metadata import download_oracle_names
 
 from ..domains.materials import MacroMolecule, SmallMolecule
-from .core import PropertyValue
+from .core import PropertyValue, IpAdressParameters, ApiTokenParameters
 from .scores import SCORING_FACTORY
 
 
@@ -188,3 +189,38 @@ def get_target_parameters(
         score_list.append(SCORING_FACTORY[scoring_function_name](**parameters))
         weights.append(weight)
     return (score_list, weights)
+
+
+def validate_ip(ip: str, message: str = "") -> None:
+    """
+    Validates whether the parameter configuration contains a correct IP
+    address.
+
+    Args:
+        ip: The IP address to validate.
+        message: Additional error message to be displayed.
+    """
+
+    try:
+        ipaddress.ip_address(ip)
+    except ValueError:
+        raise ValueError(f"{ip} is not a IPv4 or IPv6 address\n {message}")
+
+
+def validate_api_token(parameters: ApiTokenParameters, message: str = "") -> None:
+    """
+    Validates whether the parameter configuration contains something
+    that _could_ be a valid API key.
+
+    Args:
+        parameters: ApiTokenParameters.
+        message: Additional error message to be displayed.
+    """
+
+    if not hasattr(parameters, "api_token"):
+        raise AttributeError(f"API key missing in {parameters}")
+
+    if not isinstance(parameters.api_token, str):
+        raise TypeError(
+            f"API key has to be a string not {parameters.api_token}\n {message}"
+        )

--- a/src/gt4sd/properties/utils.py
+++ b/src/gt4sd/properties/utils.py
@@ -32,7 +32,7 @@ from tdc.chem_utils.oracle.oracle import fp2fpfunc
 from tdc.metadata import download_oracle_names
 
 from ..domains.materials import MacroMolecule, SmallMolecule
-from .core import PropertyValue, IpAdressParameters, ApiTokenParameters
+from .core import ApiTokenParameters, PropertyValue
 from .scores import SCORING_FACTORY
 
 

--- a/src/gt4sd/training_pipelines/tests/test_training_regression_transformer.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_regression_transformer.py
@@ -44,7 +44,6 @@ from gt4sd.training_pipelines.core import TrainingPipelineArguments
 
 template_config = {
     "model_args": {},
-    "dataset_args": {"test_fraction": 0.5},
     "training_args": {
         "training_name": "regression-transformer-test",
         "batch_size": 4,

--- a/src/gt4sd/training_pipelines/tests/test_training_regression_transformer.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_regression_transformer.py
@@ -44,6 +44,7 @@ from gt4sd.training_pipelines.core import TrainingPipelineArguments
 
 template_config = {
     "model_args": {},
+    "dataset_args": {},
     "training_args": {
         "training_name": "regression-transformer-test",
         "batch_size": 4,


### PR DESCRIPTION
Closes #119 
Closes #117 

- bumping tdc dependency which finally allows to relax the sklearn version
- support for three more complex oracles.  For details see [here](https://tdcommons.ai/functions/oracles/).
  - Two of them (ASKCOS and MoleculeOne) give synthesizability scores similar to RXN retroworkers. They need an api key or a the IP of the API endpoint to run. I created schemata to handle those 
  - Third run is for docking. I simply populated the TDC interface that either allows to dock against an existing target (that is fetched automatically from their server) or against a user-provided target. In both cases, however, the user needs to install a lot of software manually before these properties work
  - No unit tests provided in all cases, since installation is either manual or requires authentification

- I had to temporarily pin `importlib_metadata` since they just released v5 which comes with some errors, see [here](https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean), original issue [here](https://github.com/python/importlib_metadata/issues/409)
- Unrelated: I fixed the legacy values of `test_fraction` in RT Trainer code
- Unrelated: Renamed `SIDER` property to `Sider` in order to adhere to our styling