### PR TITLE
fix: change default to true

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ tensorflow==2.1.0
 torchdrug>=0.1.2
 torchmetrics<0.7
 torchvision>=0.12.0
-transformers>=4.2.1
+transformers>=4.22.0
 typing_extensions>=3.7.4.3
 wheel>=0.26
 importlib-metadata<5.0.0 # temporary: https://github.com/python/importlib_metadata/issues/409

--- a/src/gt4sd/cli/trainer.py
+++ b/src/gt4sd/cli/trainer.py
@@ -121,7 +121,9 @@ class TrainerArgumentParser(ArgumentParser):
             if "gt4sd.cli.trainer.TrainerArguments" not in str(dataclass_type)
         ]
         try:
-            parsed_arguments = super().parse_json_file(json_file=json_file)
+            parsed_arguments = super().parse_json_file(
+                json_file=json_file, allow_extra_keys=True
+            )
         except Exception:
             logger.exception(
                 f"error parsing configuration file: {json_file}, printing error and exiting"


### PR DESCRIPTION
`transformers==4.22.0` changed `parse_json_file(self, json_file: str, allow_extra_keys: bool = False)`, with allow_extra_keys=False as default and raising an error. We always use extra_keys in the library and this change breaks the training pipeline.