### PR TITLE
Wheel issue and pkg_resource refactor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ datasets>=1.11.0
 diffusers>=0.2.4
 ipaddress>=1.0.23
 joblib>=1.1.0
+importlib-metadata>=1.7.0
+importlib-resources>=5.10.0
 keras==2.3.1
 keybert==0.2.0
 minio==7.0.1
@@ -33,4 +35,3 @@ torchvision>=0.12.0
 transformers>=4.22.0
 typing_extensions>=3.7.4.3
 wheel>=0.26
-importlib-metadata<5.0.0 # temporary: https://github.com/python/importlib_metadata/issues/409

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ datasets>=1.11.0
 diffusers>=0.2.4
 ipaddress>=1.0.23
 joblib>=1.1.0
-importlib-metadata>=1.7.0
+importlib-metadata>=1.7.0,<5.0.0 # temporary: https://github.com/python/importlib_metadata/issues/409
 importlib-resources>=5.10.0
 keras==2.3.1
 keybert==0.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,18 +34,19 @@ install_requires =
     sacremoses
     scikit-learn
     scikit-optimize
+    scipy
     sentencepiece
     sympy
     tables
     tape-proteins
     tensorboard
-    tensorflow
     torch
     torchdrug
     torchmetrics
     torchvision
     transformers
     typing_extensions
+    wheel
 setup_requires =
     setuptools
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ install_requires =
     datasets
     diffusers
     ipaddress
+    importlib_metadata
+    importlib_resources
     joblib
     keras
     keybert
@@ -188,9 +190,6 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-molecule_generation.*]
-ignore_missing_imports = True
-
-[mypy-pkg_resources.*]
 ignore_missing_imports = True
 
 [mypy-tdc.*]

--- a/src/gt4sd/__init__.py
+++ b/src/gt4sd/__init__.py
@@ -23,7 +23,7 @@
 #
 """Module initialization."""
 
-__version__ = "0.50.0"
+__version__ = "0.51.0"
 __name__ = "gt4sd"
 
 # NOTE: configure SSL to allow unverified contexts by default

--- a/src/gt4sd/conftest.py
+++ b/src/gt4sd/conftest.py
@@ -22,11 +22,6 @@
 # SOFTWARE.
 #
 """Make pytest fixtures available to multiple test directories."""
-import atexit
-from contextlib import ExitStack
-from pathlib import PosixPath
-
-import importlib_resources
 import pytest
 
 
@@ -34,21 +29,3 @@ import pytest
 def mock_wrong_s3_env(monkeypatch):
     """Changes an environment variable to break the s3 connection."""
     monkeypatch.setenv("GT4SD_S3_SECRET_KEY", "(╯°□°）╯︵ ┻━┻")
-
-
-def exitclose_file_creator(file_path: str) -> PosixPath:
-    """
-    Creates an absolute filepath that is closed at exit time.
-
-    Args:
-        file_path: A relative path to a file for which the context handler is created.
-
-    Returns:
-        PosixPath: An absolute filepath.
-    """
-
-    file_manager = ExitStack()
-    atexit.register(file_manager.close)
-    ref = importlib_resources.files("gt4sd") / file_path
-    absolute_path = file_manager.enter_context(importlib_resources.as_file(ref))
-    return absolute_path

--- a/src/gt4sd/conftest.py
+++ b/src/gt4sd/conftest.py
@@ -22,7 +22,11 @@
 # SOFTWARE.
 #
 """Make pytest fixtures available to multiple test directories."""
+import atexit
+from contextlib import ExitStack
+from pathlib import PosixPath
 
+import importlib_resources
 import pytest
 
 
@@ -30,3 +34,21 @@ import pytest
 def mock_wrong_s3_env(monkeypatch):
     """Changes an environment variable to break the s3 connection."""
     monkeypatch.setenv("GT4SD_S3_SECRET_KEY", "(╯°□°）╯︵ ┻━┻")
+
+
+def exitclose_file_creator(file_path: str) -> PosixPath:
+    """
+    Creates an absolute filepath that is closed at exit time.
+
+    Args:
+        file_path: A relative path to a file for which the context handler is created.
+
+    Returns:
+        PosixPath: An absolute filepath.
+    """
+
+    file_manager = ExitStack()
+    atexit.register(file_manager.close)
+    ref = importlib_resources.files("gt4sd") / file_path
+    absolute_path = file_manager.enter_context(importlib_resources.as_file(ref))
+    return absolute_path

--- a/src/gt4sd/tests/utils.py
+++ b/src/gt4sd/tests/utils.py
@@ -23,8 +23,12 @@
 #
 """Utilities used in the tests."""
 
+import atexit
+from contextlib import ExitStack
 from functools import lru_cache
+from pathlib import PosixPath
 
+import importlib_resources
 from pydantic import BaseSettings
 
 
@@ -45,3 +49,21 @@ class GT4SDTestSettings(BaseSettings):
     @lru_cache(maxsize=None)
     def get_instance() -> "GT4SDTestSettings":
         return GT4SDTestSettings()
+
+
+def exitclose_file_creator(file_path: str) -> PosixPath:
+    """
+    Creates an absolute filepath that is closed at exit time.
+
+    Args:
+        file_path: A relative path to a file for which the context handler is created.
+
+    Returns:
+        PosixPath: An absolute filepath.
+    """
+
+    file_manager = ExitStack()
+    atexit.register(file_manager.close)
+    ref = importlib_resources.files("gt4sd") / file_path
+    absolute_path = file_manager.enter_context(importlib_resources.as_file(ref))
+    return absolute_path

--- a/src/gt4sd/training_pipelines/__init__.py
+++ b/src/gt4sd/training_pipelines/__init__.py
@@ -23,11 +23,13 @@
 #
 """Module initialization for gt4sd traning pipelines."""
 
+import atexit
 import json
 import logging
+from contextlib import ExitStack
 from typing import Any, Dict
 
-import pkg_resources
+import importlib_resources
 
 from ..cli.load_arguments_from_dataclass import extract_fields_from_class
 from .diffusion.core import (
@@ -208,16 +210,15 @@ def training_pipeline_name_to_metadata(name: str) -> Dict[str, Any]:
     Returns:
         dictionary describing the parameters of the pipeline. If the pipeline is not found, no metadata (a.k.a., an empty dictionary is returned).
     """
+    file_manager = ExitStack()
+    atexit.register(file_manager.close)
+
     metadata: Dict[str, Any] = {"training_pipeline": name, "parameters": {}}
     if name in TRAINING_PIPELINE_NAME_METADATA_MAPPING:
         try:
-            with open(
-                pkg_resources.resource_filename(
-                    "gt4sd",
-                    f"training_pipelines/{TRAINING_PIPELINE_NAME_METADATA_MAPPING[name]}",
-                ),
-                "rt",
-            ) as fp:
+            ref = importlib_resources.files("my.package") / "resource.dat"
+            path = file_manager.enter_context(importlib_resources.as_file(ref))
+            with open(path, "rt") as fp:
                 metadata["parameters"] = json.load(fp)
         except Exception:
             logger.exception(

--- a/src/gt4sd/training_pipelines/__init__.py
+++ b/src/gt4sd/training_pipelines/__init__.py
@@ -27,10 +27,8 @@ import json
 import logging
 from typing import Any, Dict
 
-import importlib_resources
-
 from ..cli.load_arguments_from_dataclass import extract_fields_from_class
-from ..conftest import exitclose_file_creator
+from ..tests.utils import exitclose_file_creator
 from .diffusion.core import (
     DiffusionDataArguments,
     DiffusionForVisionTrainingPipeline,

--- a/src/gt4sd/training_pipelines/__init__.py
+++ b/src/gt4sd/training_pipelines/__init__.py
@@ -23,15 +23,14 @@
 #
 """Module initialization for gt4sd traning pipelines."""
 
-import atexit
 import json
 import logging
-from contextlib import ExitStack
 from typing import Any, Dict
 
 import importlib_resources
 
 from ..cli.load_arguments_from_dataclass import extract_fields_from_class
+from ..conftest import exitclose_file_creator
 from .diffusion.core import (
     DiffusionDataArguments,
     DiffusionForVisionTrainingPipeline,
@@ -210,14 +209,13 @@ def training_pipeline_name_to_metadata(name: str) -> Dict[str, Any]:
     Returns:
         dictionary describing the parameters of the pipeline. If the pipeline is not found, no metadata (a.k.a., an empty dictionary is returned).
     """
-    file_manager = ExitStack()
-    atexit.register(file_manager.close)
 
     metadata: Dict[str, Any] = {"training_pipeline": name, "parameters": {}}
     if name in TRAINING_PIPELINE_NAME_METADATA_MAPPING:
         try:
-            ref = importlib_resources.files("my.package") / "resource.dat"
-            path = file_manager.enter_context(importlib_resources.as_file(ref))
+            path = exitclose_file_creator(
+                f"training_pipelines/{TRAINING_PIPELINE_NAME_METADATA_MAPPING[name]}"
+            )
             with open(path, "rt") as fp:
                 metadata["parameters"] = json.load(fp)
         except Exception:

--- a/src/gt4sd/training_pipelines/pytorch_lightning/language_modeling/lm_datasets.py
+++ b/src/gt4sd/training_pipelines/pytorch_lightning/language_modeling/lm_datasets.py
@@ -27,6 +27,7 @@ import json
 import logging
 import os
 from functools import lru_cache
+from pathlib import PosixPath
 from typing import Any, Callable, Dict, List, Union
 
 import sentencepiece as _sentencepiece
@@ -155,7 +156,7 @@ class DataModule(pl.LightningDataModule):
                     self.dataset_args["num_dataloader_workers"], cpus_count
                 )
 
-    def build_dataset(self, path: str) -> Dataset:
+    def build_dataset(self, path: Union[str, PosixPath]) -> Dataset:
         """
         Build the dataset.
 
@@ -164,7 +165,7 @@ class DataModule(pl.LightningDataModule):
         Returns:
             a torch Dataset.
         """
-
+        path = str(path)
         if path.endswith(".jsonl") or path.endswith(".json"):
             return LMDataset(path, self.tokenize_function)
         elif os.path.isdir(path):

--- a/src/gt4sd/training_pipelines/tests/test_training_diffusion.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_diffusion.py
@@ -28,16 +28,9 @@ import shutil
 import tempfile
 from typing import Any, Dict, cast
 
-import pkg_resources
-
 from gt4sd.training_pipelines import (
     TRAINING_PIPELINE_MAPPING,
     DiffusionForVisionTrainingPipeline,
-)
-
-TEST_DATA_DIRECTORY = pkg_resources.resource_filename(
-    "gt4sd",
-    "training_pipelines/tests/",
 )
 
 

--- a/src/gt4sd/training_pipelines/tests/test_training_gflownet.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_gflownet.py
@@ -29,18 +29,12 @@ import tempfile
 from typing import Any, Dict, cast
 
 import numpy as np
-import pkg_resources
 import pytest
 
 from gt4sd.frameworks.gflownet.envs.graph_building_env import GraphBuildingEnv
 from gt4sd.frameworks.gflownet.envs.mol_building_env import MolBuildingEnvContext
 from gt4sd.frameworks.gflownet.tests.qm9 import QM9Dataset, QM9GapTask
 from gt4sd.training_pipelines import TRAINING_PIPELINE_MAPPING, GFlowNetTrainingPipeline
-
-TEST_DATA_DIRECTORY = pkg_resources.resource_filename(
-    "gt4sd",
-    "training_pipelines/tests/",
-)
 
 
 def _create_training_output_filepaths(directory: str) -> Dict[str, str]:

--- a/src/gt4sd/training_pipelines/tests/test_training_guacamol_baselines_smiles_lstm.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_guacamol_baselines_smiles_lstm.py
@@ -23,21 +23,15 @@
 #
 """GuacaMol LSTM trainer unit tests."""
 
-import os
 import shutil
 import tempfile
 from typing import Any, Dict, cast
 
-import pkg_resources
+import importlib_resources
 
 from gt4sd.training_pipelines import (
     TRAINING_PIPELINE_MAPPING,
     GuacaMolLSTMTrainingPipeline,
-)
-
-TEST_DATA_DIRECTORY = pkg_resources.resource_filename(
-    "gt4sd",
-    "training_pipelines/tests/",
 )
 
 template_config = {
@@ -68,11 +62,14 @@ def test_train():
     test_pipeline = cast(GuacaMolLSTMTrainingPipeline, pipeline())
 
     config: Dict[str, Any] = template_config.copy()
-    file_path = os.path.join(TEST_DATA_DIRECTORY, "molecules.smiles")
-    config["training_args"]["output_dir"] = TEMPORARY_DIRECTORY
-    config["dataset_args"]["train_smiles_filepath"] = file_path
-    config["dataset_args"]["test_smiles_filepath"] = file_path
 
-    test_pipeline.train(**config)
+    with importlib_resources.as_file(
+        importlib_resources.files("gt4sd") / "training_pipelines/tests/molecules.smiles"
+    ) as file_path:
+        config["training_args"]["output_dir"] = TEMPORARY_DIRECTORY
+        config["dataset_args"]["train_smiles_filepath"] = file_path
+        config["dataset_args"]["test_smiles_filepath"] = file_path
+
+        test_pipeline.train(**config)
 
     shutil.rmtree(TEMPORARY_DIRECTORY)

--- a/src/gt4sd/training_pipelines/tests/test_training_language_modeling.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_language_modeling.py
@@ -26,7 +26,7 @@
 from typing import cast
 
 import sentencepiece as _sentencepiece
-import pkg_resources
+import importlib_resources
 from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 
 from gt4sd.training_pipelines import (
@@ -94,25 +94,24 @@ def test_get_data_and_model_modules_mlm():
 
     config = template_config.copy()
 
-    file_path = pkg_resources.resource_filename(
-        "gt4sd",
-        "training_pipelines/tests/lm_example.jsonl",
-    )
+    with importlib_resources.as_file(
+        importlib_resources.files("gt4sd") / "training_pipelines/tests/lm_example.jsonl"
+    ) as file_path:
 
-    config["dataset_args"]["train_file"] = file_path
+        config["dataset_args"]["train_file"] = file_path
 
-    config["dataset_args"]["validation_file"] = file_path
-    config["model_args"]["type"] = "mlm"
+        config["dataset_args"]["validation_file"] = file_path
+        config["model_args"]["type"] = "mlm"
 
-    data_module, model_module = test_pipeline.get_data_and_model_modules(
-        config["model_args"], config["dataset_args"]  # type: ignore
-    )
+        data_module, model_module = test_pipeline.get_data_and_model_modules(
+            config["model_args"], config["dataset_args"]  # type: ignore
+        )
 
-    assert isinstance(model_module, MLMModule)
-    assert isinstance(data_module, MLMDataModule)
+        assert isinstance(model_module, MLMModule)
+        assert isinstance(data_module, MLMDataModule)
 
-    check_model_config(model_module, config["model_args"])
-    check_data_config(data_module, config["dataset_args"])
+        check_model_config(model_module, config["model_args"])
+        check_data_config(data_module, config["dataset_args"])
 
 
 def test_get_data_and_model_modules_clm():
@@ -125,25 +124,24 @@ def test_get_data_and_model_modules_clm():
 
     config = template_config.copy()
 
-    file_path = pkg_resources.resource_filename(
-        "gt4sd",
-        "training_pipelines/tests/lm_example.jsonl",
-    )
+    with importlib_resources.as_file(
+        importlib_resources.files("gt4sd") / "training_pipelines/tests/lm_example.jsonl"
+    ) as file_path:
 
-    config["dataset_args"]["train_file"] = file_path
-    config["dataset_args"]["validation_file"] = file_path
-    config["model_args"]["type"] = "clm"
-    config["model_args"]["model_name_or_path"] = "gpt2"
+        config["dataset_args"]["train_file"] = file_path
+        config["dataset_args"]["validation_file"] = file_path
+        config["model_args"]["type"] = "clm"
+        config["model_args"]["model_name_or_path"] = "gpt2"
 
-    data_module, model_module = test_pipeline.get_data_and_model_modules(
-        config["model_args"], config["dataset_args"]  # type: ignore
-    )
+        data_module, model_module = test_pipeline.get_data_and_model_modules(
+            config["model_args"], config["dataset_args"]  # type: ignore
+        )
 
-    assert isinstance(model_module, CLMModule)
-    assert isinstance(data_module, CLMDataModule)
+        assert isinstance(model_module, CLMModule)
+        assert isinstance(data_module, CLMDataModule)
 
-    check_model_config(model_module, config["model_args"])
-    check_data_config(data_module, config["dataset_args"])
+        check_model_config(model_module, config["model_args"])
+        check_data_config(data_module, config["dataset_args"])
 
 
 def test_get_data_and_model_modules_cgm():
@@ -156,25 +154,24 @@ def test_get_data_and_model_modules_cgm():
 
     config = template_config.copy()
 
-    file_path = pkg_resources.resource_filename(
-        "gt4sd",
-        "training_pipelines/tests/lm_example.jsonl",
-    )
+    with importlib_resources.as_file(
+        importlib_resources.files("gt4sd") / "training_pipelines/tests/lm_example.jsonl"
+    ) as file_path:
 
-    config["dataset_args"]["train_file"] = file_path
-    config["dataset_args"]["validation_file"] = file_path
-    config["model_args"]["type"] = "cgm"
-    config["model_args"]["model_name_or_path"] = "t5-base"
+        config["dataset_args"]["train_file"] = file_path
+        config["dataset_args"]["validation_file"] = file_path
+        config["model_args"]["type"] = "cgm"
+        config["model_args"]["model_name_or_path"] = "t5-base"
 
-    data_module, model_module = test_pipeline.get_data_and_model_modules(
-        config["model_args"], config["dataset_args"]  # type: ignore
-    )
+        data_module, model_module = test_pipeline.get_data_and_model_modules(
+            config["model_args"], config["dataset_args"]  # type: ignore
+        )
 
-    assert isinstance(model_module, CGMModule)
-    assert isinstance(data_module, CGMDataModule)
+        assert isinstance(model_module, CGMModule)
+        assert isinstance(data_module, CGMDataModule)
 
-    check_model_config(model_module, config["model_args"])
-    check_data_config(data_module, config["dataset_args"])
+        check_model_config(model_module, config["model_args"])
+        check_data_config(data_module, config["dataset_args"])
 
 
 def test_get_data_and_model_modules_plm():
@@ -187,25 +184,24 @@ def test_get_data_and_model_modules_plm():
 
     config = template_config.copy()
 
-    file_path = pkg_resources.resource_filename(
-        "gt4sd",
-        "training_pipelines/tests/lm_example.jsonl",
-    )
+    with importlib_resources.as_file(
+        importlib_resources.files("gt4sd") / "training_pipelines/tests/lm_example.jsonl"
+    ) as file_path:
 
-    config["dataset_args"]["train_file"] = file_path
-    config["dataset_args"]["validation_file"] = file_path
-    config["model_args"]["type"] = "plm"
-    config["model_args"]["model_name_or_path"] = "xlnet-base-cased"
+        config["dataset_args"]["train_file"] = file_path
+        config["dataset_args"]["validation_file"] = file_path
+        config["model_args"]["type"] = "plm"
+        config["model_args"]["model_name_or_path"] = "xlnet-base-cased"
 
-    data_module, model_module = test_pipeline.get_data_and_model_modules(
-        config["model_args"], config["dataset_args"]  # type: ignore
-    )
+        data_module, model_module = test_pipeline.get_data_and_model_modules(
+            config["model_args"], config["dataset_args"]  # type: ignore
+        )
 
-    assert isinstance(model_module, PLMModule)
-    assert isinstance(data_module, PLMDataModule)
+        assert isinstance(model_module, PLMModule)
+        assert isinstance(data_module, PLMDataModule)
 
-    check_model_config(model_module, config["model_args"])
-    check_data_config(data_module, config["dataset_args"])
+        check_model_config(model_module, config["model_args"])
+        check_data_config(data_module, config["dataset_args"])
 
 
 def test_add_callbacks():

--- a/src/gt4sd/training_pipelines/tests/test_training_moses_organ.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_moses_organ.py
@@ -23,24 +23,19 @@
 #
 """Moses Organ trainer unit tests."""
 
-import atexit
 import os
 import shutil
 import tempfile
-from contextlib import ExitStack
 from typing import Any, Dict, cast
-
-import importlib_resources
 
 from gt4sd.training_pipelines import (
     TRAINING_PIPELINE_MAPPING,
     MosesOrganTrainingPipeline,
 )
 
-file_manager = ExitStack()
-atexit.register(file_manager.close)
-ref = importlib_resources.files("gt4sd") / "training_pipelines/tests/molecules.smiles"
-data_path = file_manager.enter_context(importlib_resources.as_file(ref))
+from ...conftest import exitclose_file_creator
+
+DATA_PATH = exitclose_file_creator("training_pipelines/tests/molecules.smiles")
 
 
 def _create_training_output_filepaths(directory: str) -> Dict[str, str]:
@@ -90,7 +85,7 @@ template_config = {
         "device": "cpu",
         "save_frequency": 1,
     },
-    "dataset_args": {"train_load": data_path, "val_load": data_path},
+    "dataset_args": {"train_load": DATA_PATH, "val_load": DATA_PATH},
 }
 
 

--- a/src/gt4sd/training_pipelines/tests/test_training_moses_organ.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_moses_organ.py
@@ -23,22 +23,24 @@
 #
 """Moses Organ trainer unit tests."""
 
+import atexit
 import os
 import shutil
 import tempfile
+from contextlib import ExitStack
 from typing import Any, Dict, cast
 
-import pkg_resources
+import importlib_resources
 
 from gt4sd.training_pipelines import (
     TRAINING_PIPELINE_MAPPING,
     MosesOrganTrainingPipeline,
 )
 
-TEST_DATA_DIRECTORY = pkg_resources.resource_filename(
-    "gt4sd",
-    "training_pipelines/tests/",
-)
+file_manager = ExitStack()
+atexit.register(file_manager.close)
+ref = importlib_resources.files("gt4sd") / "training_pipelines/tests/molecules.smiles"
+data_path = file_manager.enter_context(importlib_resources.as_file(ref))
 
 
 def _create_training_output_filepaths(directory: str) -> Dict[str, str]:
@@ -88,10 +90,7 @@ template_config = {
         "device": "cpu",
         "save_frequency": 1,
     },
-    "dataset_args": {
-        "train_load": os.path.join(TEST_DATA_DIRECTORY, "molecules.smiles"),
-        "val_load": os.path.join(TEST_DATA_DIRECTORY, "molecules.smiles"),
-    },
+    "dataset_args": {"train_load": data_path, "val_load": data_path},
 }
 
 

--- a/src/gt4sd/training_pipelines/tests/test_training_moses_organ.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_moses_organ.py
@@ -33,7 +33,7 @@ from gt4sd.training_pipelines import (
     MosesOrganTrainingPipeline,
 )
 
-from ...conftest import exitclose_file_creator
+from ...tests.utils import exitclose_file_creator
 
 DATA_PATH = exitclose_file_creator("training_pipelines/tests/molecules.smiles")
 

--- a/src/gt4sd/training_pipelines/tests/test_training_moses_vae.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_moses_vae.py
@@ -30,7 +30,7 @@ from typing import Any, Dict, cast
 
 from gt4sd.training_pipelines import TRAINING_PIPELINE_MAPPING, MosesVAETrainingPipeline
 
-from ...conftest import exitclose_file_creator
+from ...tests.utils import exitclose_file_creator
 
 DATA_PATH = exitclose_file_creator("training_pipelines/tests/molecules.smiles")
 

--- a/src/gt4sd/training_pipelines/tests/test_training_moses_vae.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_moses_vae.py
@@ -23,19 +23,21 @@
 #
 """Moses VAE trainer unit tests."""
 
+import atexit
 import os
 import shutil
 import tempfile
+from contextlib import ExitStack
 from typing import Any, Dict, cast
 
-import pkg_resources
+import importlib_resources
 
 from gt4sd.training_pipelines import TRAINING_PIPELINE_MAPPING, MosesVAETrainingPipeline
 
-TEST_DATA_DIRECTORY = pkg_resources.resource_filename(
-    "gt4sd",
-    "training_pipelines/tests/",
-)
+file_manager = ExitStack()
+atexit.register(file_manager.close)
+ref = importlib_resources.files("gt4sd") / "training_pipelines/tests/molecules.smiles"
+data_path = file_manager.enter_context(importlib_resources.as_file(ref))
 
 
 def _create_training_output_filepaths(directory: str) -> Dict[str, str]:
@@ -89,10 +91,7 @@ template_config = {
         "device": "cpu",
         "save_frequency": 1,
     },
-    "dataset_args": {
-        "train_load": os.path.join(TEST_DATA_DIRECTORY, "molecules.smiles"),
-        "val_load": os.path.join(TEST_DATA_DIRECTORY, "molecules.smiles"),
-    },
+    "dataset_args": {"train_load": data_path, "val_load": data_path},
 }
 
 

--- a/src/gt4sd/training_pipelines/tests/test_training_moses_vae.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_moses_vae.py
@@ -23,21 +23,16 @@
 #
 """Moses VAE trainer unit tests."""
 
-import atexit
 import os
 import shutil
 import tempfile
-from contextlib import ExitStack
 from typing import Any, Dict, cast
-
-import importlib_resources
 
 from gt4sd.training_pipelines import TRAINING_PIPELINE_MAPPING, MosesVAETrainingPipeline
 
-file_manager = ExitStack()
-atexit.register(file_manager.close)
-ref = importlib_resources.files("gt4sd") / "training_pipelines/tests/molecules.smiles"
-data_path = file_manager.enter_context(importlib_resources.as_file(ref))
+from ...conftest import exitclose_file_creator
+
+DATA_PATH = exitclose_file_creator("training_pipelines/tests/molecules.smiles")
 
 
 def _create_training_output_filepaths(directory: str) -> Dict[str, str]:
@@ -91,7 +86,7 @@ template_config = {
         "device": "cpu",
         "save_frequency": 1,
     },
-    "dataset_args": {"train_load": data_path, "val_load": data_path},
+    "dataset_args": {"train_load": DATA_PATH, "val_load": DATA_PATH},
 }
 
 

--- a/src/gt4sd/training_pipelines/tests/test_training_paccmann_vae.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_paccmann_vae.py
@@ -27,7 +27,7 @@ import shutil
 import tempfile
 from typing import Any, Dict, cast
 
-import pkg_resources
+import importlib_resources
 
 from gt4sd.training_pipelines import (
     TRAINING_PIPELINE_MAPPING,
@@ -87,14 +87,12 @@ def test_train():
     config: Dict[str, Any] = template_config.copy()
 
     config["training_args"]["model_path"] = TEMPORARY_DIRECTORY
+    with importlib_resources.as_file(
+        importlib_resources.files("gt4sd") / "training_pipelines/tests/molecules.smi",
+    ) as file_path:
 
-    file_path = pkg_resources.resource_filename(
-        "gt4sd",
-        "training_pipelines/tests/molecules.smi",
-    )
+        config["dataset_args"]["train_smiles_filepath"] = file_path
+        config["dataset_args"]["test_smiles_filepath"] = file_path
+        test_pipeline.train(**config)
 
-    config["dataset_args"]["train_smiles_filepath"] = file_path
-    config["dataset_args"]["test_smiles_filepath"] = file_path
-    test_pipeline.train(**config)
-
-    shutil.rmtree(TEMPORARY_DIRECTORY)
+        shutil.rmtree(TEMPORARY_DIRECTORY)

--- a/src/gt4sd/training_pipelines/tests/test_training_regression_transformer.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_regression_transformer.py
@@ -28,7 +28,7 @@ import os
 import tempfile
 from typing import Any, Dict, Iterable, cast
 
-import pkg_resources
+import importlib_resources
 
 from gt4sd.algorithms.conditional_generation.regression_transformer import (
     RegressionTransformerMolecules,
@@ -157,30 +157,30 @@ def test_train():
 
     config: Dict[str, Any] = template_config.copy()
     config["training_args"]["output_dir"] = TEMPORARY_DIRECTORY
-    raw_path = pkg_resources.resource_filename(
-        "gt4sd",
-        "training_pipelines/tests/regression_transformer_raw.csv",
-    )
+    with importlib_resources.as_file(
+        importlib_resources.files("gt4sd")
+        / "training_pipelines/tests/regression_transformer_raw.csv"
+    ) as raw_path:
 
-    # Test the pretrained QED model
-    config["model_args"]["model_path"] = mol_path
-    config["dataset_args"]["train_data_path"] = raw_path
-    config["dataset_args"]["test_data_path"] = raw_path
-    config["dataset_args"]["augment"] = 2
-    input_config = combine_defaults_and_user_args(config)
-    test_pipeline.train(**input_config)
-
-    # Test training model from scratch
-    with tempfile.TemporaryDirectory() as temp:
-        f_name = os.path.join(temp, "tmp_xlnet_config.json")
-        # Write file
-        with open(f_name, "w") as f:
-            json.dump(xlnet_config, f, indent=4)
-
-        config["model_args"]["config_name"] = f_name
-        del config["model_args"]["model_path"]
-        config["model_args"]["tokenizer_name"] = mol_path
-        config["dataset_args"]["data_path"] = raw_path
+        # Test the pretrained QED model
+        config["model_args"]["model_path"] = mol_path
+        config["dataset_args"]["train_data_path"] = raw_path
+        config["dataset_args"]["test_data_path"] = raw_path
         config["dataset_args"]["augment"] = 2
         input_config = combine_defaults_and_user_args(config)
         test_pipeline.train(**input_config)
+
+        # Test training model from scratch
+        with tempfile.TemporaryDirectory() as temp:
+            f_name = os.path.join(temp, "tmp_xlnet_config.json")
+            # Write file
+            with open(f_name, "w") as f:
+                json.dump(xlnet_config, f, indent=4)
+
+            config["model_args"]["config_name"] = f_name
+            del config["model_args"]["model_path"]
+            config["model_args"]["tokenizer_name"] = mol_path
+            config["dataset_args"]["data_path"] = raw_path
+            config["dataset_args"]["augment"] = 2
+            input_config = combine_defaults_and_user_args(config)
+            test_pipeline.train(**input_config)

--- a/src/gt4sd/training_pipelines/tests/test_training_torchdrug_gcpn.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_torchdrug_gcpn.py
@@ -27,7 +27,7 @@ import shutil
 import tempfile
 from typing import Any, Dict, cast
 
-import pkg_resources
+import importlib_resources
 
 from gt4sd.training_pipelines import (
     TRAINING_PIPELINE_MAPPING,
@@ -82,29 +82,29 @@ def test_train():
     shutil.rmtree(TEMPORARY_DIRECTORY)
 
     # Now test with a custom dataset
-    file_path = pkg_resources.resource_filename(
-        "gt4sd",
-        "training_pipelines/tests/molecules.csv",
-    )
-    config["dataset_args"]["dataset_name"] = "custom"
-    config["dataset_args"]["file_path"] = file_path
-    config["dataset_args"]["smiles_field"] = "smiles"
-    config["dataset_args"]["target_field"] = "qed"
-    # This should filter out the QED again from the batches
-    config["dataset_args"]["transform"] = "lambda x: {'graph': x['graph']}"
+    with importlib_resources.as_file(
+        importlib_resources.files("gt4sd") / "training_pipelines/tests/molecules.csv"
+    ) as file_path:
 
-    test_pipeline.train(**config)
-    shutil.rmtree(TEMPORARY_DIRECTORY)
+        config["dataset_args"]["dataset_name"] = "custom"
+        config["dataset_args"]["file_path"] = file_path
+        config["dataset_args"]["smiles_field"] = "smiles"
+        config["dataset_args"]["target_field"] = "qed"
+        # This should filter out the QED again from the batches
+        config["dataset_args"]["transform"] = "lambda x: {'graph': x['graph']}"
 
-    # Test the property optimization
-    """
-    Disabled for now due to multiple downstream torchdrug issues, most importantly:
-    - https://github.com/DeepGraphLearning/torchdrug/issues/83
-    """
-    # config["dataset_args"]["target_field"] = 'qed'
-    # config['training_args']['task'] = 'qed'
-    # config['data_args']['node_feature'] = 'symbol'
-    # config['model_args']['criterion'] = "{'ppo': 1}"
+        test_pipeline.train(**config)
+        shutil.rmtree(TEMPORARY_DIRECTORY)
 
-    # test_pipeline.train(**config)
-    # shutil.rmtree(TEMPORARY_DIRECTORY)
+        # Test the property optimization
+        """
+        Disabled for now due to multiple downstream torchdrug issues, most importantly:
+        - https://github.com/DeepGraphLearning/torchdrug/issues/83
+        """
+        # config["dataset_args"]["target_field"] = 'qed'
+        # config['training_args']['task'] = 'qed'
+        # config['data_args']['node_feature'] = 'symbol'
+        # config['model_args']['criterion'] = "{'ppo': 1}"
+
+        # test_pipeline.train(**config)
+        # shutil.rmtree(TEMPORARY_DIRECTORY)

--- a/src/gt4sd/training_pipelines/tests/test_training_torchdrug_graphaf.py
+++ b/src/gt4sd/training_pipelines/tests/test_training_torchdrug_graphaf.py
@@ -27,7 +27,7 @@ import shutil
 import tempfile
 from typing import Any, Dict, cast
 
-import pkg_resources
+import importlib_resources
 
 from gt4sd.training_pipelines import (
     TRAINING_PIPELINE_MAPPING,
@@ -82,27 +82,26 @@ def test_train():
     shutil.rmtree(TEMPORARY_DIRECTORY)
 
     # Now test with a custom dataset
-    file_path = pkg_resources.resource_filename(
-        "gt4sd",
-        "training_pipelines/tests/molecules.csv",
-    )
-    config["dataset_args"]["dataset_name"] = "custom"
-    config["dataset_args"]["file_path"] = file_path
-    config["dataset_args"]["smiles_field"] = "smiles"
-    config["dataset_args"]["target_field"] = "qed"
+    with importlib_resources.as_file(
+        importlib_resources.files("gt4sd") / "training_pipelines/tests/molecules.csv"
+    ) as file_path:
+        config["dataset_args"]["dataset_name"] = "custom"
+        config["dataset_args"]["file_path"] = file_path
+        config["dataset_args"]["smiles_field"] = "smiles"
+        config["dataset_args"]["target_field"] = "qed"
 
-    test_pipeline.train(**config)
-    shutil.rmtree(TEMPORARY_DIRECTORY)
+        test_pipeline.train(**config)
+        shutil.rmtree(TEMPORARY_DIRECTORY)
 
-    # Test the property optimization
-    """
-    Disabled for now due to multiple downstream torchdrug issues, most importantly:
-    - https://github.com/DeepGraphLearning/torchdrug/issues/83
-    """
-    # config["dataset_args"]["target_field"] = 'qed'
-    # config['training_args']['task'] = 'qed'
-    # config['data_args']['node_feature'] = 'symbol'
-    # config['model_args']['criterion'] = "{'ppo': 1}"
+        # Test the property optimization
+        """
+        Disabled for now due to multiple downstream torchdrug issues, most importantly:
+        - https://github.com/DeepGraphLearning/torchdrug/issues/83
+        """
+        # config["dataset_args"]["target_field"] = 'qed'
+        # config['training_args']['task'] = 'qed'
+        # config['data_args']['node_feature'] = 'symbol'
+        # config['model_args']['criterion'] = "{'ppo': 1}"
 
-    # test_pipeline.train(**config)
-    # shutil.rmtree(TEMPORARY_DIRECTORY)
+        # test_pipeline.train(**config)
+        # shutil.rmtree(TEMPORARY_DIRECTORY)

--- a/src/gt4sd/training_pipelines/torchdrug/unpatch.py
+++ b/src/gt4sd/training_pipelines/torchdrug/unpatch.py
@@ -24,7 +24,7 @@
 import typing
 from typing import List
 
-import pkg_resources
+import importlib_metadata
 import torch
 from packaging import version
 from torch.optim.lr_scheduler import (  # type: ignore
@@ -61,7 +61,7 @@ sane_datasets = [
     TensorDataset,
 ]
 
-torch_version = version.parse(pkg_resources.get_distribution("torch").version)
+torch_version = version.parse(importlib_metadata.version("torch"))
 
 if torch_version < version.parse("1.12") and torch_version >= version.parse("1.10"):
     from torch.utils.data.dataset import DFIterDataPipe  # type: ignore


### PR DESCRIPTION
Closes #146 

This PR:
- makes `scipy` an explicit dependencies of the PyPI package since it's used directly inside GFlowNets and it removes `tensorflow` from that list since it's not used directly anywhere. This removal by itself already solved #146
- I took the opportunity to migrate from `pkg_resources` to importlib, since in #146 `pkg_resources` was complaining. This was done also because use of `pkg_resources` is discouraged in favor of `importlib`. Note that we install `importlib_metadata` and `importlib_resources` from PyPI which are backports of the standardlibrary packages (`importlib.*`) which are only available for Python 3.8+. I did this to support python 3.7 and 3.8+ without conditional imports

