### PR TITLE
Tolerance values RegressionTransformer

### DIFF
--- a/examples/regression_transformer/README.md
+++ b/examples/regression_transformer/README.md
@@ -15,6 +15,23 @@ To launch a finetuning of a RT pretrained on drug-like moelcules from ChEMBL, ex
 ```
 *NOTE*: This is *dummy* example, do not use "as is" :warning:
 
+*NOTE*: :warning: The above assumes that you have the `qed` model cached locally. If this is not the case, run an inference to trigger the caching mechanism:
+
+```py
+from gt4sd.algorithms.registry import ApplicationsRegistry
+algorithm = ApplicationsRegistry.get_application_instance(
+  target='CCO',
+  sampling_wrapper={'property_goal': {'<qed>': 0.12}},
+  algorithm_type='conditional_generation',
+  domain='materials',
+  algorithm_name='RegressionTransformer',
+  algorithm_application='RegressionTransformerMolecules',
+  algorithm_version='qed'
+)
+```
+Consider replacing `algorithm_version='qed'`, dependent on which model you want to finetune.
+
+
 For details on this methodology see:
 
 ```bib

--- a/src/gt4sd/algorithms/conditional_generation/regression_transformer/core.py
+++ b/src/gt4sd/algorithms/conditional_generation/regression_transformer/core.py
@@ -192,10 +192,15 @@ class RegressionTransformerMolecules(AlgorithmConfiguration[Sequence, Sequence])
         default=8,
         metadata=dict(description="Batch size for the conditional generation"),
     )
-    tolerance: float = field(
+    tolerance: Union[float, Dict[str, float]] = field(
         default=20.0,
         metadata=dict(
-            description="Precision tolerance for the conditional generation task. Given in percent"
+            description="""Precision tolerance for the conditional generation task. This is the
+            tolerated eviation between desired/primed property and predicted property of the
+            generated molecule. Given in percentage with respect to the property range encountered
+            during training. Either a single float or a dict of floats with properties as
+            NOTE: The tolerance is *only* used for post-hoc filtering of the generated molecules.
+            """
         ),
     )
     sampling_wrapper: Dict = field(
@@ -342,10 +347,15 @@ class RegressionTransformerProteins(AlgorithmConfiguration[Sequence, Sequence]):
         default=32,
         metadata=dict(description="Batch size for the conditional generation"),
     )
-    tolerance: float = field(
+    tolerance: Union[float, Dict[str, float]] = field(
         default=20.0,
         metadata=dict(
-            description="Precision tolerance for the conditional generation task. Given in percent"
+            description="""Precision tolerance for the conditional generation task. This is the
+            tolerated eviation between desired/primed property and predicted property of the
+            generated molecule. Given in percentage with respect to the property range encountered
+            during training. Either a single float or a dict of floats with properties as
+            NOTE: The tolerance is *only* used for post-hoc filtering of the generated proteins.
+            """
         ),
     )
     sampling_wrapper: Dict = field(

--- a/src/gt4sd/algorithms/generation/diffusion/implementation.py
+++ b/src/gt4sd/algorithms/generation/diffusion/implementation.py
@@ -26,11 +26,11 @@ Implementation details for huggingface diffusers generation algorithms.
 
 Parts of the implementation inspired by: https://github.com/huggingface/diffusers/blob/main/examples/train_unconditional.py.
 """
-
 import logging
 import os
 from typing import Any, List, Optional, Union
 
+import importlib_metadata
 import numpy as np
 import torch
 from diffusers import (
@@ -45,8 +45,13 @@ from diffusers import (
     ScoreSdeVeScheduler,
     StableDiffusionPipeline,
 )
+from packaging import version
 
 from ....frameworks.torch import device_claim
+
+OLD_DIFFUSERS = version.parse(importlib_metadata.version("diffusers")) < version.parse(
+    "0.6.0"
+)
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -153,5 +158,9 @@ class Generator:
             item = self.model(batch_size=number_samples, prompt=self.prompt)
         else:
             item = self.model(batch_size=number_samples)
-        item = item["sample"]
+        # To support old diffusers versions (<0.6.0)
+        if OLD_DIFFUSERS:
+            item = item["sample"]
+        else:
+            item = item.images
         return item

--- a/src/gt4sd/algorithms/generation/diffusion/implementation.py
+++ b/src/gt4sd/algorithms/generation/diffusion/implementation.py
@@ -49,7 +49,7 @@ from packaging import version
 
 from ....frameworks.torch import device_claim
 
-OLD_DIFFUSERS = version.parse(importlib_metadata.version("diffusers")) < version.parse(
+DIFFUSERS_VERSION_LT_0_6_0 = version.parse(importlib_metadata.version("diffusers")) < version.parse(
     "0.6.0"
 )
 
@@ -159,7 +159,7 @@ class Generator:
         else:
             item = self.model(batch_size=number_samples)
         # To support old diffusers versions (<0.6.0)
-        if OLD_DIFFUSERS:
+        if DIFFUSERS_VERSION_LT_0_6_0:
             item = item["sample"]
         else:
             item = item.images

--- a/src/gt4sd/algorithms/generation/diffusion/implementation.py
+++ b/src/gt4sd/algorithms/generation/diffusion/implementation.py
@@ -49,9 +49,9 @@ from packaging import version
 
 from ....frameworks.torch import device_claim
 
-DIFFUSERS_VERSION_LT_0_6_0 = version.parse(importlib_metadata.version("diffusers")) < version.parse(
-    "0.6.0"
-)
+DIFFUSERS_VERSION_LT_0_6_0 = version.parse(
+    importlib_metadata.version("diffusers")
+) < version.parse("0.6.0")
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/src/gt4sd/training_pipelines/diffusion/core.py
+++ b/src/gt4sd/training_pipelines/diffusion/core.py
@@ -128,7 +128,7 @@ class DiffusionForVisionTrainingPipeline(TrainingPipeline):
         )
         # ddpm noise schedule
         noise_scheduler = DDPMScheduler(
-            num_train_timesteps=params["num_train_timesteps"], tensor_format="pt"
+            num_train_timesteps=params["num_train_timesteps"]
         )
         optimizer = torch.optim.AdamW(
             model.parameters(),

--- a/src/gt4sd/training_pipelines/torchdrug/graphaf/core.py
+++ b/src/gt4sd/training_pipelines/torchdrug/graphaf/core.py
@@ -221,7 +221,9 @@ class TorchDrugGraphAFTrainingPipeline(TorchDrugTrainingPipeline):
             # Save model
             task_name = f"task={params.get('task')}_" if params.get("task") else ""
             data_name = "data=" + (
-                dataset_name + "_" + params["file_path"].split(os.sep)[-1].split(".")[0]
+                dataset_name
+                + "_"
+                + str(params["file_path"]).split(os.sep)[-1].split(".")[0]
                 if dataset_name == "custom"
                 else dataset_name
             )


### PR DESCRIPTION
- Expanding controllability of the tolerances by setting one tolerance value per property. So tolerance can be provided as `float` or now also as `Dict[str, float]`. Missing keys are imputed with 20% and additional keys are ignored. Warnings are raised. Tests are implemented.
Example:
```py
target = 'C1(=O)O[C@@H](C)C(=O)O[C@H]1C.C2CC(NC(NC1=CC=C(OC)C=C1)=S)CCC2'
config = RegressionTransformerMolecules(
    algorithm_version='logp_and_synthesizability', search='sample', tolerance={'<logp>': 20, '<scs>': 10},
    sampling_wrapper={
        'property_goal': {'<logp>': 0.15, '<scs>': 3.5}, 'fraction_to_mask': 0.4, 'tokens_to_mask': ['C']
    }
)
generator = RegressionTransformer(
    configuration=config, target=target
)
```
- I found a bug in my previous tolerance implementation, basically the provided tolerance was not passed down and we always used a tolerance of 20%... My bad. It's fixed now.
- Clarified the README about RT finetuning, stating that the model has to be cached locally for this to work. This relates to #156 but I'm not sure we have to trigger syncing from HF model hub about RT models. None of the RT models is available in HF model hub.

Housekeeping:
- Support new version of `diffusers` (0.6.0) while maintaining support for older ones


