### PR TITLE
Bumping pydantic >= 2.0.0

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -14,3 +14,4 @@ sphinx>=5
 sphinx-autodoc-typehints==1.11.1
 jinja2<3.1.0
 sphinx_rtd_theme==0.5.1
+pydantic-settings>=2.0.0

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -13,5 +13,3 @@ pytest-cov==2.10.1
 sphinx>=5
 sphinx-autodoc-typehints==1.11.1
 jinja2<3.1.0
-sphinx_rtd_theme==0.5.1
-pydantic-settings>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,5 @@ transformers>=4.22.0,<=4.24.0
 typing_extensions>=3.7.4.3
 wheel>=0.26
 xgboost>=1.7.6
+sphinx_rtd_theme==0.5.1
+pydantic-settings>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ numpy>=1.16.5,<1.24.0
 pandas<=2.0.3
 protobuf<3.20
 pyarrow>=8.0.0
-pydantic>=1.7.3,<2.0.0
+pydantic>=2.0.0
 pymatgen>=2022.11.7
 PyTDC==0.3.7
 pytorch_lightning<=1.7.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -291,3 +291,6 @@ ignore_missing_imports = True
 
 [mypy-xgboost.*]
 ignore_missing_imports = True
+
+[mypy-pydantic_settings.*]
+ignore_missing_imports = True

--- a/src/gt4sd/__init__.py
+++ b/src/gt4sd/__init__.py
@@ -23,7 +23,7 @@
 #
 """Module initialization."""
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 __name__ = "gt4sd"
 
 # NOTE: configure SSL to allow unverified contexts by default

--- a/src/gt4sd/algorithms/core.py
+++ b/src/gt4sd/algorithms/core.py
@@ -912,8 +912,6 @@ def get_configuration_class_with_attributes(
 
 
 class PropertyPredictor(ABC, Generic[S, U]):
-    """TODO: Might be deprecated in future release."""
-
     def __init__(self, context: U) -> None:
         """Property predictor to investigate items.
 

--- a/src/gt4sd/algorithms/registry.py
+++ b/src/gt4sd/algorithms/registry.py
@@ -28,7 +28,17 @@ import logging
 from dataclasses import dataclass as vanilla_dataclass
 from dataclasses import field, make_dataclass
 from functools import WRAPPER_ASSIGNMENTS, update_wrapper
-from typing import Any, Callable, ClassVar, Dict, List, NamedTuple, Optional, Type, TypeVar
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Type,
+    TypeVar,
+)
 
 import pydantic
 
@@ -186,7 +196,7 @@ class ApplicationsRegistry:
                 ],  # type: ignore
             )
             # NOTE: Needed to circumvent a pydantic TypeError: Parameter list to Generic[...] cannot be empty
-            VanillaConfiguration.__parameters__ = (TypeVar('T'),)
+            VanillaConfiguration.__parameters__ = (TypeVar("T"),)
             # NOTE: Duplicate call necessary for pydantic >=1.10.* - see https://github.com/pydantic/pydantic/issues/4695
             PydanticConfiguration: Type[AlgorithmConfiguration] = dataclass(  # type: ignore
                 VanillaConfiguration

--- a/src/gt4sd/algorithms/registry.py
+++ b/src/gt4sd/algorithms/registry.py
@@ -28,7 +28,7 @@ import logging
 from dataclasses import dataclass as vanilla_dataclass
 from dataclasses import field, make_dataclass
 from functools import WRAPPER_ASSIGNMENTS, update_wrapper
-from typing import Any, Callable, ClassVar, Dict, List, NamedTuple, Optional, Type
+from typing import Any, Callable, ClassVar, Dict, List, NamedTuple, Optional, Type, TypeVar
 
 import pydantic
 
@@ -186,8 +186,7 @@ class ApplicationsRegistry:
                 ],  # type: ignore
             )
             # NOTE: Needed to circumvent a pydantic TypeError: Parameter list to Generic[...] cannot be empty
-            VanillaConfiguration.__pydantic_validator__ = True  # type: ignore
-
+            VanillaConfiguration.__parameters__ = (TypeVar('T'),)
             # NOTE: Duplicate call necessary for pydantic >=1.10.* - see https://github.com/pydantic/pydantic/issues/4695
             PydanticConfiguration: Type[AlgorithmConfiguration] = dataclass(  # type: ignore
                 VanillaConfiguration

--- a/src/gt4sd/algorithms/registry.py
+++ b/src/gt4sd/algorithms/registry.py
@@ -196,7 +196,7 @@ class ApplicationsRegistry:
                 ],  # type: ignore
             )
             # NOTE: Needed to circumvent a pydantic TypeError: Parameter list to Generic[...] cannot be empty
-            VanillaConfiguration.__parameters__ = (TypeVar("T"),)
+            VanillaConfiguration.__parameters__ = (TypeVar("T"),) # type: ignore
             # NOTE: Duplicate call necessary for pydantic >=1.10.* - see https://github.com/pydantic/pydantic/issues/4695
             PydanticConfiguration: Type[AlgorithmConfiguration] = dataclass(  # type: ignore
                 VanillaConfiguration

--- a/src/gt4sd/algorithms/registry.py
+++ b/src/gt4sd/algorithms/registry.py
@@ -186,7 +186,7 @@ class ApplicationsRegistry:
                 ],  # type: ignore
             )
             # NOTE: Needed to circumvent a pydantic TypeError: Parameter list to Generic[...] cannot be empty
-            VanillaConfiguration.__pydantic_validator__ = True
+            VanillaConfiguration.__pydantic_validator__ = True  # type: ignore
 
             # NOTE: Duplicate call necessary for pydantic >=1.10.* - see https://github.com/pydantic/pydantic/issues/4695
             PydanticConfiguration: Type[AlgorithmConfiguration] = dataclass(  # type: ignore

--- a/src/gt4sd/algorithms/registry.py
+++ b/src/gt4sd/algorithms/registry.py
@@ -196,7 +196,7 @@ class ApplicationsRegistry:
                 ],  # type: ignore
             )
             # NOTE: Needed to circumvent a pydantic TypeError: Parameter list to Generic[...] cannot be empty
-            VanillaConfiguration.__parameters__ = (TypeVar("T"),) # type: ignore
+            VanillaConfiguration.__parameters__ = (TypeVar("T"),)  # type: ignore
             # NOTE: Duplicate call necessary for pydantic >=1.10.* - see https://github.com/pydantic/pydantic/issues/4695
             PydanticConfiguration: Type[AlgorithmConfiguration] = dataclass(  # type: ignore
                 VanillaConfiguration

--- a/src/gt4sd/algorithms/registry.py
+++ b/src/gt4sd/algorithms/registry.py
@@ -185,6 +185,9 @@ class ApplicationsRegistry:
                     ),
                 ],  # type: ignore
             )
+            # NOTE: Needed to circumvent a pydantic TypeError: Parameter list to Generic[...] cannot be empty
+            VanillaConfiguration.__pydantic_validator__ = True
+
             # NOTE: Duplicate call necessary for pydantic >=1.10.* - see https://github.com/pydantic/pydantic/issues/4695
             PydanticConfiguration: Type[AlgorithmConfiguration] = dataclass(  # type: ignore
                 VanillaConfiguration

--- a/src/gt4sd/algorithms/tests/test_registry.py
+++ b/src/gt4sd/algorithms/tests/test_registry.py
@@ -58,21 +58,15 @@ def test_list_available_local_via_S3SyncError(mock_wrong_s3_env):
 
 def test_inherited_validation():
     Config = next(iter(ApplicationsRegistry.applications.values())).configuration_class
-    with pytest.raises(
-        ValidationError, match="should be a valid string"
-    ):
+    with pytest.raises(ValidationError, match="should be a valid string"):
         Config(algorithm_version=None)  # type: ignore
 
-    with pytest.raises(
-        ValidationError, match="should be a valid string"
-    ):
+    with pytest.raises(ValidationError, match="should be a valid string"):
         Config(algorithm_version=5)  # type: ignore
 
 
 def test_validation():
-    with pytest.raises(
-        ValidationError, match="should be a valid integer"
-    ):
+    with pytest.raises(ValidationError, match="should be a valid integer"):
         ApplicationsRegistry.get_configuration_instance(
             algorithm_type="conditional_generation",
             domain="materials",

--- a/src/gt4sd/algorithms/tests/test_registry.py
+++ b/src/gt4sd/algorithms/tests/test_registry.py
@@ -59,17 +59,19 @@ def test_list_available_local_via_S3SyncError(mock_wrong_s3_env):
 def test_inherited_validation():
     Config = next(iter(ApplicationsRegistry.applications.values())).configuration_class
     with pytest.raises(
-        ValidationError, match="algorithm_version\n +none is not an allowed value"
+        ValidationError, match="should be a valid string"
     ):
         Config(algorithm_version=None)  # type: ignore
 
-    # NOTE: values convertible to string will not raise!
-    Config(algorithm_version=5)  # type: ignore
+    with pytest.raises(
+        ValidationError, match="should be a valid string"
+    ):
+        Config(algorithm_version=5)  # type: ignore
 
 
 def test_validation():
     with pytest.raises(
-        ValidationError, match="batch_size\n +value is not a valid integer"
+        ValidationError, match="should be a valid integer"
     ):
         ApplicationsRegistry.get_configuration_instance(
             algorithm_type="conditional_generation",
@@ -78,25 +80,6 @@ def test_validation():
             algorithm_application="PaccMannRLProteinBasedGenerator",
             batch_size="wrong_type",
         )
-
-
-def test_pickable_wrapped_configurations():
-    # https://github.com/samuelcolvin/pydantic/issues/2111
-    Config = next(iter(ApplicationsRegistry.applications.values())).configuration_class
-    restored_obj = assert_pickable(Config(algorithm_version="test"))
-
-    # wrong type assignment, but we did not configure it to raise here:
-    restored_obj.algorithm_version = object
-    # ensure the restored dataclass is still a pydantic dataclass (mimic validation)
-    _, optional_errors = restored_obj.__pydantic_model__.__fields__.get(
-        "algorithm_version"
-    ).validate(
-        restored_obj.algorithm_version,
-        restored_obj.__dict__,
-        loc="algorithm_version",
-        cls=restored_obj.__class__,
-    )
-    assert optional_errors is not None
 
 
 def test_multiple_registration():

--- a/src/gt4sd/configuration.py
+++ b/src/gt4sd/configuration.py
@@ -28,9 +28,8 @@ import os
 from functools import lru_cache
 from typing import Dict, Optional, Set
 
-from pydantic import BaseSettings
-
 from .s3 import GT4SDS3Client, S3SyncError, sync_folder_with_s3, upload_file_to_s3
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -65,10 +64,7 @@ class GT4SDConfiguration(BaseSettings):
     gt4sd_s3_secure_hub: bool = True
     gt4sd_s3_bucket_hub_algorithms: str = "gt4sd-cos-hub-algorithms-artifacts"
     gt4sd_s3_bucket_hub_properties: str = "gt4sd-cos-hub-properties-artifacts"
-
-    class Config:
-        # immutable and in turn hashable, that is required for lru_cache
-        frozen = True
+    model_config = SettingsConfigDict(frozen=True)
 
     @staticmethod
     @lru_cache(maxsize=None)

--- a/src/gt4sd/configuration.py
+++ b/src/gt4sd/configuration.py
@@ -27,9 +27,9 @@ import logging
 import os
 from functools import lru_cache
 from typing import Dict, Optional, Set
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .s3 import GT4SDS3Client, S3SyncError, sync_folder_with_s3, upload_file_to_s3
-from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/src/gt4sd/properties/core.py
+++ b/src/gt4sd/properties/core.py
@@ -49,7 +49,9 @@ class S3Parameters(PropertyPredictorParameters):
     domain: DomainSubmodule = Field(
         ..., examples=["molecules"], description="Submodule of gt4sd.properties"
     )
-    algorithm_name: str = Field(..., examples=["MCA"], description="Name of the algorithm")
+    algorithm_name: str = Field(
+        ..., examples=["MCA"], description="Name of the algorithm"
+    )
     algorithm_version: str = Field(
         ..., examples=["v0"], description="Version of the algorithm"
     )

--- a/src/gt4sd/properties/core.py
+++ b/src/gt4sd/properties/core.py
@@ -47,19 +47,19 @@ class S3Parameters(PropertyPredictorParameters):
     algorithm_type: str = "prediction"
 
     domain: DomainSubmodule = Field(
-        ..., example="molecules", description="Submodule of gt4sd.properties"
+        ..., examples=["molecules"], description="Submodule of gt4sd.properties"
     )
-    algorithm_name: str = Field(..., example="MCA", description="Name of the algorithm")
+    algorithm_name: str = Field(..., examples=["MCA"], description="Name of the algorithm")
     algorithm_version: str = Field(
-        ..., example="v0", description="Version of the algorithm"
+        ..., examples=["v0"], description="Version of the algorithm"
     )
-    algorithm_application: str = Field(..., example="Tox21")
+    algorithm_application: str = Field(..., examples=["Tox21"])
 
 
 class ApiTokenParameters(PropertyPredictorParameters):
     api_token: str = Field(
         ...,
-        example="apk-c9db......",
+        examples=["apk-c9db......"],
         description="The API token/key to access the service",
     )
 
@@ -68,7 +68,7 @@ class IpAdressParameters(PropertyPredictorParameters):
 
     host_ip: str = Field(
         ...,
-        example="xx.xx.xxx.xxx",
+        examples=["xx.xx.xxx.xxx"],
         description="The host IP address to access the service",
     )
 

--- a/src/gt4sd/properties/molecules/core.py
+++ b/src/gt4sd/properties/molecules/core.py
@@ -59,7 +59,7 @@ from paccmann_generator.drug_evaluators import ClinTox as _ClinTox
 from paccmann_generator.drug_evaluators import OrganDB as _OrganTox
 from paccmann_generator.drug_evaluators import SCScore
 from paccmann_generator.drug_evaluators import Tox21 as _Tox21
-from pydantic import Field
+from pydantic import ConfigDict, Field
 from tdc import Oracle
 from tdc.metadata import download_receptor_oracle_name
 
@@ -119,12 +119,12 @@ class ScscoreConfiguration(PropertyPredictorParameters):
 
 
 class SimilaritySeedParameters(PropertyPredictorParameters):
-    smiles: str = Field(..., example="c1ccccc1")
+    smiles: str = Field(..., examples=["c1ccccc1"])
     fp_key: str = "ECFP4"
 
 
 class ActivityAgainstTargetParameters(PropertyPredictorParameters):
-    target: str = Field(..., example="drd2", description="name of the target.")
+    target: str = Field(..., examples=["drd2"], description="name of the target.")
 
 
 class AskcosParameters(IpAdressParameters):
@@ -136,7 +136,7 @@ class AskcosParameters(IpAdressParameters):
 
     output: Output = Field(
         default=Output.plausability,
-        example=Output.synthesizability,
+        examples=[Output.synthesizability],
         description="Main output return type from ASKCOS",
         options=["plausibility", "num_step", "synthesizability", "price"],
     )
@@ -159,10 +159,7 @@ class AskcosParameters(IpAdressParameters):
     min_chempop_products: int = Field(default=5)
     filter_threshold: float = Field(default=0.1)
     return_first: str = Field(default="true")
-
-    # Convert enum items back to strings
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 
 class MoleculeOneParameters(ApiTokenParameters):
@@ -174,7 +171,7 @@ class DockingTdcParameters(PropertyPredictorParameters):
     # To dock against a receptor defined via TDC
     target: str = Field(
         ...,
-        example="1iep_docking",
+        examples=["1iep_docking"],
         description="Target for docking, provided via TDC",
         options=download_receptor_oracle_name,
     )
@@ -184,12 +181,12 @@ class DockingParameters(PropertyPredictorParameters):
     # To dock against a user-provided receptor
     name: str = Field(default="pyscreener")
     receptor_pdb_file: str = Field(
-        example="/tmp/2hbs.pdb", description="Path to receptor PDB file"
+        examples=["/tmp/2hbs.pdb"], description="Path to receptor PDB file"
     )
     box_center: List[int] = Field(
-        example=[15.190, 53.903, 16.917], description="Docking box center"
+        examples=[[15.190, 53.903, 16.917]], description="Docking box center"
     )
-    box_size: List[float] = Field(example=[20, 20, 20], description="Docking box size")
+    box_size: List[float] = Field(examples=[[20, 20, 20]], description="Docking box size")
 
 
 class S3ParametersMolecules(S3Parameters):
@@ -265,12 +262,12 @@ class OrganToxParameters(MCAParameters):
     algorithm_application: str = "OrganTox"
     site: Organs = Field(
         ...,
-        example=Organs.kidney,
+        examples=[Organs.kidney],
         description="name of the target site of interest.",
     )
     toxicity_type: ToxType = Field(
         default=ToxType.all,
-        example=ToxType.chronic,
+        examples=[ToxType.chronic],
         description="type of toxicity for which predictions are made.",
         options=["chronic", "subchronic", "multigenerational", "all"],
     )

--- a/src/gt4sd/properties/molecules/core.py
+++ b/src/gt4sd/properties/molecules/core.py
@@ -186,7 +186,9 @@ class DockingParameters(PropertyPredictorParameters):
     box_center: List[int] = Field(
         examples=[[15.190, 53.903, 16.917]], description="Docking box center"
     )
-    box_size: List[float] = Field(examples=[[20, 20, 20]], description="Docking box size")
+    box_size: List[float] = Field(
+        examples=[[20, 20, 20]], description="Docking box size"
+    )
 
 
 class S3ParametersMolecules(S3Parameters):

--- a/src/gt4sd/properties/molecules/core.py
+++ b/src/gt4sd/properties/molecules/core.py
@@ -138,7 +138,6 @@ class AskcosParameters(IpAdressParameters):
         default=Output.plausability,
         examples=[Output.synthesizability],
         description="Main output return type from ASKCOS",
-        options=["plausibility", "num_step", "synthesizability", "price"],
     )
     save_json: bool = Field(default=False)
     file_name: str = Field(default="tree_builder_result.json")
@@ -171,9 +170,8 @@ class DockingTdcParameters(PropertyPredictorParameters):
     # To dock against a receptor defined via TDC
     target: str = Field(
         ...,
-        examples=["1iep_docking"],
+        examples=download_receptor_oracle_name,
         description="Target for docking, provided via TDC",
-        options=download_receptor_oracle_name,
     )
 
 
@@ -271,7 +269,6 @@ class OrganToxParameters(MCAParameters):
         default=ToxType.all,
         examples=[ToxType.chronic],
         description="type of toxicity for which predictions are made.",
-        options=["chronic", "subchronic", "multigenerational", "all"],
     )
 
 

--- a/src/gt4sd/properties/proteins/core.py
+++ b/src/gt4sd/properties/proteins/core.py
@@ -46,7 +46,7 @@ from .functions import (
 class AmideConfiguration(PropertyPredictorParameters):
     amide: bool = Field(
         False,
-        example=False,
+        examples=[False],
         description="whether the sequences are C-terminally amidated.",
     )
 
@@ -58,7 +58,7 @@ class PhConfiguration(PropertyPredictorParameters):
 class AmidePhConfiguration(PropertyPredictorParameters):
     amide: bool = Field(
         False,
-        example=False,
+        examples=[False],
         description="whether the sequences are C-terminally amidated.",
     )
     ph: float = 7.0

--- a/src/gt4sd/tests/utils.py
+++ b/src/gt4sd/tests/utils.py
@@ -29,7 +29,7 @@ from functools import lru_cache
 from pathlib import PosixPath
 
 import importlib_resources
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class GT4SDTestSettings(BaseSettings):
@@ -40,10 +40,7 @@ class GT4SDTestSettings(BaseSettings):
     gt4sd_s3_secret_key: str = "5748375c761a4f09c30a68cd15e218e3b27ca3e2aebd7726"
     gt4sd_s3_secure: bool = True
     gt4sd_ci: bool = False
-
-    class Config:
-        # immutable and in turn hashable, that is required for lru_cache
-        frozen = True
+    model_config = SettingsConfigDict(frozen=True)
 
     @staticmethod
     @lru_cache(maxsize=None)


### PR DESCRIPTION
Problem:
- HF Spaces apps are getting down due to deprecated gradio version
- Compliant gradio version relies on pydantic 2.*
- GT4SD relies on pydantic 1.*

--> Goal: Bump pydantic

Refactor is largely done but not all tests are passing yet.

Without the hacky line
```py
            VanillaConfiguration.__pydantic_validator__ = True  # type: ignore
```

we get:
```sh
TypeError: Parameter list to Generic[...] cannot be empty
```

It would be best to find a way to have a non-empty parameter list here.
